### PR TITLE
Add talks implementation plan and sitemap-based URL contract tests

### DIFF
--- a/docs/talks-implementation-plan.md
+++ b/docs/talks-implementation-plan.md
@@ -1,0 +1,267 @@
+# Talks Section Implementation Plan
+
+## Conflict Check Against `docs/solution-design.md`
+
+No direct conflicts found.
+
+The requested talks planning work aligns with the canonical model and implementation phases in `docs/solution-design.md`, especially:
+
+- canonical `Document` + `Event` + `Redirect` model
+- event extraction from talk `deliveredAt`
+- deterministic event deduplication
+- collection-driven rendering in 11ty
+- explicit support for future extensibility via nested metadata and stable IDs
+
+## Goals
+
+Implement a first-class talks experience that:
+
+1. Imports and normalizes talks from `sources/davidwesst.github.io`.
+2. Generates canonical pages for:
+   - talks index
+   - talk detail pages
+   - event index
+   - event detail pages
+3. Establishes bidirectional linked data:
+   - talk -> events (`eventRefs`)
+   - event -> talks (derived reverse relation)
+4. Leaves room for future related entities (blog posts, talk instances, slide decks, videos) without breaking current model contracts.
+
+## Scope and Boundaries
+
+### In Scope (Now)
+
+- Talk ingestion from the davidwesst source.
+- Event extraction from talk metadata.
+- Event deduplication and canonical IDs.
+- URL planning for talks and events.
+- Rendering talks and events using canonical data only.
+- Redirect coverage for moved or renamed legacy paths.
+
+### Deferred (Future Phases)
+
+- New root canonical types beyond `Document`, `Event`, `Redirect`.
+- Fuzzy event matching.
+- Rich knowledge graph UI beyond essential cross-links.
+
+## Source Audit and Ingestion Plan
+
+### 1) Inventory Existing Talk Records
+
+Create a source audit task that collects, for each talk markdown file:
+
+- source path
+- source slug/permalink
+- title/summary/body
+- dates
+- `deliveredAt[]` entries (including title/date/location/links)
+- talk-level links (slides/video/repo if present)
+- image/media metadata
+- any additional front matter fields
+
+Output of audit: a machine-readable inventory used to validate parsing coverage and detect schema variance.
+
+### 2) Loader Updates (`davidwesst.github.io`)
+
+Extend the source loader to parse talks into source-raw records while preserving authored front matter losslessly in `meta.sourceMeta`.
+
+Requirements:
+
+- No template-level parsing logic.
+- No canonical naming in templates.
+- Keep all non-canonical fields in raw metadata for future promotion.
+
+## Canonical Data Model Plan for Talks
+
+### 1) Canonical `Document` for Talks
+
+Map each talk to:
+
+- `docType: "talk"`
+- `series: "talks"`
+- canonical `slug`, `title`, `summary`, `body`, `dates`, `taxonomy`, `media`
+- `eventRefs[]` populated from normalized event mapping
+- `meta` carrying source provenance and native field retention
+
+### 2) Canonical `Event` Extraction
+
+For each talk's delivered instances:
+
+- create event candidates from `deliveredAt[]`
+- normalize title/date/location/links
+- dedupe using precedence from solution design:
+  1. explicit source event id
+  2. `(title, date)`
+  3. `(title, startDate, location)`
+
+### 3) Reverse Linking (Derived, Not Stored Redundantly)
+
+Derive event-to-talk relationships in computed data:
+
+- Build a resolver/index: `eventId -> talkDocumentIds[]`
+- Use this for event detail rendering and related-talk lists
+- Avoid duplicating canonical relationships in both records at write time
+
+## URL and Page Generation Plan
+
+### Canonical URL Shape (Proposed)
+
+- Talks index: `/talks/`
+- Talk detail: `/talks/<slug>/`
+- Events index: `/events/`
+- Event detail: `/events/<event-slug>/`
+
+If legacy talk URLs already match desired talk detail paths, preserve as canonical and reduce redirect churn.
+
+### Page Generation
+
+1. **Talk index page**
+   - list talks sorted by `dates.sort` (fallback: published)
+   - include latest event badge if available
+
+2. **Talk detail page**
+   - render talk content
+   - render delivered-at timeline from resolved `Event` records
+   - render links specific to each occurrence via `eventRefs.links`
+
+3. **Event index page**
+   - list events sorted by `dates.sort`
+   - show count of related talks
+
+4. **Event detail page**
+   - render event metadata (date/location/shared links)
+   - render related talks via reverse index
+
+## Redirect Planning
+
+For each talk and event page:
+
+- collect legacy source URLs
+- compare to canonical URLs
+- emit `Redirect` records for non-canonical paths
+- validate:
+  - unique `from`
+  - no chains
+  - direct final target
+
+
+## URL Verification Test Plan
+
+Add data-driven URL contract tests so talks/event URL behavior is machine-validated during implementation.
+
+### Contract Inputs
+
+Use a contract fixture containing:
+
+- canonical talks and events URLs
+- legacy talk page URLs from old site shapes
+- expected redirect target for each legacy URL
+- expected HTTP status (`301`)
+
+### Required Assertions
+
+1. Canonical URL list has no duplicates and matches canonical path shape (`/path/`).
+2. Every legacy talk page URL either:
+   - remains canonical as-is, or
+   - has exactly one 301 redirect to the canonical talk/event URL.
+3. Redirect `from` paths are unique.
+4. Redirect targets are canonical URLs.
+5. No redirect chains are allowed.
+
+### Initial Test Harness
+
+- `tests/playwright/sitemap-urls.spec.js`: Playwright contract tests for sitemap-backed canonical URLs and legacy redirects.
+- `tests/url_contracts/talks_url_contract.json`: fixture for legacy talk/event URLs and expected redirect targets/status.
+- `playwright.config.js`: serves built `_site/` locally for URL tests.
+
+Sitemap prerequisites:
+
+- Generate `/_site/sitemap.xml` at build time using an Eleventy sitemap plugin (prefer `@quasibit/eleventy-plugin-sitemap` in `.eleventy.js`).
+- Ensure talk and event pages are included in sitemap output before running tests.
+
+This harness verifies URLs against actual built site output, not hand-maintained route lists.
+
+## Future-Proof Linked Data Extensions
+
+To support blog posts, talk instances, slide decks, and other related artifacts without adding root types prematurely:
+
+### 1) Extend `Document` Through Nested Metadata
+
+- Add optional nested extension areas under `meta.sourceMeta` first.
+- Promote only stable, cross-source fields into canonical nested objects after observed repetition.
+
+### 2) Add Optional Relationship References
+
+Plan optional relationship arrays on `Document` in a backward-compatible way, for example:
+
+- `relatedDocumentRefs[]` for blog posts derived from talks
+- `assetRefs[]` for slide deck/video/repository resources
+
+These should be introduced as additive fields with deterministic IDs and URL-safe references.
+
+### 3) Consider Talk Occurrences as Event-Centric Instead of New Root Type
+
+Before introducing `TalkInstance` as a new root type, model occurrences as:
+
+- `eventRefs` + optional occurrence-level metadata
+- canonical `Event` records for shared venue/date semantics
+
+Only add a new root type if eventRef metadata becomes structurally overloaded.
+
+## Implementation Phases
+
+### Phase A — Data Foundations
+
+- Add/verify talks loader coverage.
+- Add normalization mapping for talk fields and `deliveredAt`.
+- Add event candidate extraction tests.
+
+### Phase B — Event Resolution
+
+- Implement deterministic event dedupe.
+- Assign stable event IDs/slugs.
+- Build reverse relation index (`eventId -> talks`).
+
+### Phase C — URL and Redirect Layer
+
+- Assign canonical URLs for talks/events.
+- Generate legacy redirect records.
+- Add collision/chain validation checks.
+
+### Phase D — 11ty Rendering
+
+- Expose `_data/documents.js`, `_data/events.js`, `_data/redirects.js` slices needed for talks/events.
+- Implement collections: `talks`, `events`.
+- Implement talks/events index/detail pages.
+
+### Phase E — Validation and Content QA
+
+- Relationship integrity checks:
+  - all `eventRefs.eventId` resolve
+  - each event page has deterministic related-talk list
+- URL and redirect checks.
+- Snapshot or fixture tests for representative talks/events.
+
+## Acceptance Criteria
+
+1. Every talk source entry is represented as one canonical talk `Document`.
+2. Every delivered occurrence is represented as or merged into canonical `Event` records.
+3. Talk pages show linked events; event pages show linked talks.
+4. Canonical URL and redirects are deterministic and chain-free.
+5. Templates use canonical fields only (no source-specific keys).
+6. Future linkage to blog posts/slides can be added additively without schema breakage.
+
+## Suggested Initial Task Breakdown (Backlog-Ready)
+
+1. Create talk source fixture set from `/sources/davidwesst.github.io`.
+2. Implement/verify talk loader parsing and source metadata retention.
+3. Implement talk normalization mapping to canonical `Document`.
+4. Implement event candidate extraction from talk `deliveredAt`.
+5. Implement event dedupe + stable id/slug generation.
+6. Implement reverse relation index for event -> talks.
+7. Implement talks/events canonical URL generation.
+8. Implement redirect generation + redirect validator updates.
+9. Implement talks index/detail templates bound to normalized data.
+10. Implement events index/detail templates with related talks.
+11. Add integration tests for one multi-event talk and one shared event.
+12. Add QA checklist for URL parity with legacy paths.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,109 @@
+{
+  "name": "website",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "website",
+      "devDependencies": {
+        "@playwright/test": "^1.55.0",
+        "fast-xml-parser": "^4.5.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.6.tgz",
+      "integrity": "sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "website",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test:urls": "playwright test tests/playwright/sitemap-urls.spec.js"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.55.0",
+    "fast-xml-parser": "^4.5.0"
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/playwright',
+  timeout: 30_000,
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:8080'
+  }
+});

--- a/tests/playwright/sitemap-urls.spec.js
+++ b/tests/playwright/sitemap-urls.spec.js
@@ -1,0 +1,64 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { test, expect } from '@playwright/test';
+import { XMLParser } from 'fast-xml-parser';
+
+const repoRoot = process.cwd();
+const sitemapPath = path.join(repoRoot, '_site', 'sitemap.xml');
+const legacyContractPath = path.join(repoRoot, 'tests', 'url_contracts', 'talks_url_contract.json');
+
+function readSitemapUrls() {
+  if (!fs.existsSync(sitemapPath)) {
+    throw new Error('Missing _site/sitemap.xml. Build the 11ty site with sitemap generation before running this test.');
+  }
+
+  const xml = fs.readFileSync(sitemapPath, 'utf8');
+  const parser = new XMLParser({ ignoreAttributes: false });
+  const parsed = parser.parse(xml);
+
+  const urlNodes = parsed?.urlset?.url ?? [];
+  const urls = Array.isArray(urlNodes) ? urlNodes : [urlNodes];
+
+  return urls.map((entry) => {
+    const loc = entry?.loc;
+    if (!loc) throw new Error('Sitemap contains an entry with no <loc>.');
+    return new URL(loc).pathname;
+  });
+}
+
+function readLegacyRedirects() {
+  const raw = fs.readFileSync(legacyContractPath, 'utf8');
+  const data = JSON.parse(raw);
+  return data.redirects ?? [];
+}
+
+test('sitemap exists and has canonical talk/event URLs', async ({ request }) => {
+  const paths = readSitemapUrls();
+
+  expect(paths.length).toBeGreaterThan(0);
+  expect(new Set(paths).size).toBe(paths.length);
+  expect(paths).toContain('/talks/');
+  expect(paths).toContain('/events/');
+
+  for (const pathname of paths) {
+    const response = await request.get(pathname, { maxRedirects: 0 });
+    expect(response.status(), `Expected canonical URL to resolve: ${pathname}`).toBe(200);
+  }
+});
+
+test('legacy talk/event links redirect to canonical sitemap URLs', async ({ request }) => {
+  const canonicalPaths = new Set(readSitemapUrls());
+  const redirects = readLegacyRedirects();
+
+  for (const redirect of redirects) {
+    const response = await request.get(redirect.from, { maxRedirects: 0 });
+    expect(response.status(), `Expected redirect status for ${redirect.from}`).toBe(redirect.status);
+
+    const location = response.headers()['location'];
+    expect(location, `Expected Location header for ${redirect.from}`).toBeTruthy();
+
+    const redirectedPath = new URL(location, 'http://127.0.0.1:8080').pathname;
+    expect(redirectedPath).toBe(redirect.to);
+    expect(canonicalPaths.has(redirectedPath), `Redirect target must be in sitemap: ${redirectedPath}`).toBeTruthy();
+  }
+});

--- a/tests/url_contracts/talks_url_contract.json
+++ b/tests/url_contracts/talks_url_contract.json
@@ -1,0 +1,35 @@
+{
+  "canonical": [
+    "/talks/",
+    "/talks/example-talk/",
+    "/events/",
+    "/events/example-conference-2025/"
+  ],
+  "redirects": [
+    {
+      "from": "/talks",
+      "to": "/talks/",
+      "status": 301
+    },
+    {
+      "from": "/talks/example-talk",
+      "to": "/talks/example-talk/",
+      "status": 301
+    },
+    {
+      "from": "/events",
+      "to": "/events/",
+      "status": 301
+    },
+    {
+      "from": "/events/example-conference-2025",
+      "to": "/events/example-conference-2025/",
+      "status": 301
+    },
+    {
+      "from": "/talks/legacy-example-talk/",
+      "to": "/talks/example-talk/",
+      "status": 301
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation

- Define a concrete implementation plan for first-class talks and event data modeling, ingestion, URL shaping, and redirects to align with the canonical data model.
- Provide an automated contract to validate canonical talk/event URLs and legacy redirect behavior against actual built site output.
- Add a minimal test harness and dev dependencies to enable CI or local verification of sitemap and redirect contracts before shipping templates.

### Description

- Add `docs/talks-implementation-plan.md` containing the full ingestion, canonical model, event dedupe, URL, redirect, and phased implementation plan for talks and events.
- Add Playwright-based URL contract test `tests/playwright/sitemap-urls.spec.js` and fixture `tests/url_contracts/talks_url_contract.json` to assert sitemap canonical paths and legacy redirects.
- Add `playwright.config.js`, `package.json` with `test:urls` script and devDependencies (`@playwright/test`, `fast-xml-parser`), and a generated `package-lock.json` capturing the lock state.
- The tests require a built site sitemap at `_site/sitemap.xml` and validate that canonical URLs return `200` and that legacy `from` paths return the expected `301` to canonical `to` paths.

### Testing

- No automated tests were executed as part of this PR; only the test harness and fixtures were added.
- The added Playwright test `tests/playwright/sitemap-urls.spec.js` will verify sitemap presence, canonical URLs respond `200`, and that each legacy redirect in `tests/url_contracts/talks_url_contract.json` returns the expected status and `Location` target when run with `npm run test:urls` after building the site and installing deps.
- To run the tests locally or in CI install dependencies with `npm ci`, build the site so `_site/sitemap.xml` is present, and run `npm run test:urls`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3b4ed7ba88330907569d25905c06f)