### PR TITLE
Migrate Remaining Content

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -2,7 +2,7 @@ import pluginWebc from "@11ty/eleventy-plugin-webc";
 import sitemapPlugin from "@quasibit/eleventy-plugin-sitemap";
 import path from "node:path";
 import site from "./src/_data/site.js";
-import { getDocuments, getEvents, getPostDocuments } from "./src/_lib/content/index.js";
+import { getDocuments, getEvents, getPageDocuments, getPostDocuments } from "./src/_lib/content/index.js";
 
 export default function(eleventyConfig) {
   eleventyConfig.setInputDirectory("src");
@@ -43,6 +43,7 @@ export default function(eleventyConfig) {
   });
 
   eleventyConfig.addCollection("documents", () => getDocuments());
+  eleventyConfig.addCollection("pages", () => getPageDocuments());
   eleventyConfig.addCollection("posts", () => getPostDocuments());
   eleventyConfig.addCollection("reviews", () => getDocuments().filter((document) => document.docType === "review"));
   eleventyConfig.addCollection("sessions", () => getDocuments().filter((document) => document.docType === "session"));

--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -8,5 +8,6 @@ export default {
     { label: "Blog", url: "/blog/" },
     { label: "Talks", url: "/talks/" },
     { label: "Events", url: "/events/" },
+    { label: "Projects", url: "/projects/" },
   ],
 };

--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -4,9 +4,9 @@ export default {
   url: "https://example.com",
   navigation: [
     { label: "Home", url: "/" },
+    { label: "About", url: "/about/" },
     { label: "Blog", url: "/blog/" },
     { label: "Talks", url: "/talks/" },
     { label: "Events", url: "/events/" },
-    { label: "Site Index", url: "/site-index/" },
   ],
 };

--- a/src/_includes/components/home-intro.webc
+++ b/src/_includes/components/home-intro.webc
@@ -20,11 +20,12 @@
 <nav class="terminal-section" aria-labelledby="home-sections-title">
   <p class="terminal-prompt" id="home-sections-title">~/davidwesst ls</p>
   <ul class="terminal-links">
+    <li><a href="/about/">about/</a></li>
     <li><a href="/blog/">blog/</a></li>
     <li><a href="/talks/">talks/</a></li>
     <li><a href="/events/">events/</a></li>
     <li><a href="/blog/?series=gamelog">gamelog/</a></li>
-    <li><a href="/site-index/">site-index/</a></li>
+    <li><a href="/blog/?series=dungeonlog">dungeonlog/</a></li>
   </ul>
 </nav>
 

--- a/src/_includes/components/home-intro.webc
+++ b/src/_includes/components/home-intro.webc
@@ -21,6 +21,7 @@
   <p class="terminal-prompt" id="home-sections-title">~/davidwesst ls</p>
   <ul class="terminal-links">
     <li><a href="/about/">about/</a></li>
+    <li><a href="/projects/">projects/</a></li>
     <li><a href="/blog/">blog/</a></li>
     <li><a href="/talks/">talks/</a></li>
     <li><a href="/events/">events/</a></li>

--- a/src/_lib/content/index.js
+++ b/src/_lib/content/index.js
@@ -1,11 +1,11 @@
-import { loadEvents, loadPosts, loadTalks } from "./loaders/local-content.js";
+import { loadEvents, loadPages, loadPosts, loadTalks } from "./loaders/local-content.js";
 import { normalizeContent } from "./normalize-content.js";
 
 let cachedContent;
 
 export function getContent() {
   if (!cachedContent) {
-    cachedContent = normalizeContent({ talks: loadTalks(), events: loadEvents(), posts: loadPosts() });
+    cachedContent = normalizeContent({ talks: loadTalks(), events: loadEvents(), posts: loadPosts(), pages: loadPages() });
   }
 
   return cachedContent;
@@ -17,6 +17,10 @@ export function getDocuments() {
 
 export function getPostDocuments() {
   return getDocuments().filter((document) => ["blog", "gamelog", "dungeonlog"].includes(document.series));
+}
+
+export function getPageDocuments() {
+  return getDocuments().filter((document) => document.docType === "page");
 }
 
 export function getEvents() {

--- a/src/_lib/content/loaders/local-content.js
+++ b/src/_lib/content/loaders/local-content.js
@@ -6,6 +6,7 @@ const SOURCE = "website";
 const TALK_ROOT = path.resolve("src/content/talks");
 const EVENT_ROOT = path.resolve("src/content/events");
 const POST_ROOT = path.resolve("src/content/posts");
+const PAGE_ROOT = path.resolve("src/content/pages");
 
 function discoverAssets(directory) {
   return fs
@@ -105,4 +106,35 @@ export function loadPosts({ root = POST_ROOT } = {}) {
         })
         .filter(Boolean);
     });
+}
+
+export function loadPages({ root = PAGE_ROOT } = {}) {
+  if (!fs.existsSync(root)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const directory = path.join(root, entry.name);
+      const nativePath = path.join(directory, "index.md");
+
+      if (!fs.existsSync(nativePath)) {
+        return null;
+      }
+
+      const parsed = matter(fs.readFileSync(nativePath, "utf8"));
+
+      return {
+        source: parsed.data.source || SOURCE,
+        type: parsed.data.docType || "page",
+        slug: parsed.data.slug || entry.name,
+        nativePath,
+        body: parsed.content.trim(),
+        data: parsed.data,
+        assets: discoverAssets(directory),
+      };
+    })
+    .filter(Boolean);
 }

--- a/src/_lib/content/normalize-content.js
+++ b/src/_lib/content/normalize-content.js
@@ -186,6 +186,36 @@ function normalizePost(raw) {
   });
 }
 
+function normalizePage(raw) {
+  const slug = raw.data.slug || raw.slug;
+  const canonicalUrl = normalizeUrlPath(raw.data.canonicalUrl || `/${slug}/`);
+  const legacyUrls = (raw.data.legacyUrls || [])
+    .map(normalizeLegacyUrl)
+    .filter((legacyUrl) => legacyUrl !== canonicalUrl);
+
+  return removeUndefined({
+    id: raw.data.id || slug,
+    source: raw.data.source || raw.source,
+    docType: raw.data.docType || "page",
+    slug,
+    title: raw.data.title,
+    summary: raw.data.summary,
+    body: {
+      markdown: raw.body,
+    },
+    dates: normalizeDates(raw.data.dates || raw.data),
+    taxonomy: normalizeTaxonomy(raw.data.taxonomy || raw.data),
+    media: normalizeMedia(raw.data.media, canonicalUrl),
+    canonicalUrl,
+    legacyUrls,
+    meta: {
+      nativePath: raw.nativePath,
+      sourceMeta: raw.data.meta?.sourceMeta || {},
+      assets: raw.assets,
+    },
+  });
+}
+
 function normalizeEvent(raw) {
   const event = raw.data;
   const slug = event.slug || event.id;
@@ -307,8 +337,8 @@ function sortDocuments(left, right) {
   return rightSort.localeCompare(leftSort) || left.title.localeCompare(right.title);
 }
 
-export function normalizeContent({ talks = [], events = [], posts = [] }) {
-  const documents = [...talks.map(normalizeTalk), ...posts.map(normalizePost)];
+export function normalizeContent({ talks = [], events = [], posts = [], pages = [] }) {
+  const documents = [...pages.map(normalizePage), ...talks.map(normalizeTalk), ...posts.map(normalizePost)];
   const normalizedEvents = events.map(normalizeEvent);
 
   validateContent(documents, normalizedEvents);

--- a/src/assets/site.css
+++ b/src/assets/site.css
@@ -315,6 +315,29 @@ time {
   max-width: 58ch;
 }
 
+.project-entry + .project-entry {
+  border-block-start: var(--line);
+  margin-block-start: var(--space-2xl);
+  padding-block-start: var(--space-2xl);
+}
+
+.project-status {
+  color: var(--color-muted);
+  font-family: var(--font-mono);
+  margin-block: 0 var(--space-md);
+}
+
+.project-entry--active .project-status,
+.project-entry--active .project-status span {
+  font-weight: 700;
+}
+
+.project-entry--archived .project-status,
+.project-entry--archived .project-status span {
+  font-style: italic;
+  font-weight: 400;
+}
+
 .post-filters,
 .feed-links {
   display: flex;

--- a/src/assets/site.css
+++ b/src/assets/site.css
@@ -223,6 +223,7 @@ samp {
 
 .terminal-section,
 .page-header,
+.page-detail,
 .post-detail,
 .talk-detail,
 .event-detail {

--- a/src/content/pages/about/index.md
+++ b/src/content/pages/about/index.md
@@ -1,0 +1,58 @@
+---
+id: about
+source: davidwesst.github.io
+docType: page
+slug: about
+title: About
+summary: About David Wesst, his work, background, and current interests.
+canonicalUrl: /about/
+legacyUrls:
+  - /about.html
+taxonomy:
+  tags: []
+  categories: []
+---
+Hullo. My name is David Wesst, but you can call me DW or Wessty. I am a solution architect based out of Winnipeg, Manitoba, Canada who loves building code, learning tech, and playing video games while attempting to develop my own.
+
+Find me on [GitHub](https://github.com/davidwesst/), [LinkedIn](https://ca.linkedin.com/in/davidwesst), or [YouTube](https://youtube.com/davidwesst) once and a while.
+
+## Current Building
+
+- A video game project (TBA)
+- This [website](https://github.com/davidwesst/website) out of [Eleventy](https://11ty.dev)
+
+## Currently Learning
+
+- [Godot Engine](https://godotengine.org)
+- [Microsoft Fabric & Power BI](https://learn.microsoft.com/en-us/training/paths/get-started-fabric/)
+
+## Currently Playing
+
+- Keep Driving (Steam)
+- Astro Bot (PS5)
+
+## The Short Version
+
+As a Solution Architect at the University of Manitoba, I specialize in modernizing legacy enterprise systems with a focus on user experience and cloud-centric platforms. With a Bachelor of Computer Science and nine years as a Microsoft MVP, I have built expertise in web technologies like HTML, CSS, and .NET, while sharing insights at conferences across North America. Outside work, I channel my passion for video games into designing original creations through Cocoboko Studios, combining technical innovation with creative storytelling.
+
+## The Long Version
+
+### My Work
+
+I am a solution architect at the University of Manitoba, focused on the migration of legacy enterprise systems and bringing them into modern, more cloud-focused platforms.
+
+When I am not working in and around software code, I am usually talking about it in a public venue. Since the late 2000s, I have prepared and delivered original content for in-person technology conferences across North America, and continue that tradition whenever the opportunity arises.
+
+Through my career, there has always been a recurring theme in my work: user experience focus and customer enablement. Whether I was coding the solution directly, or creating a plan to migrate enterprise resource management (ERP) systems, the focus on the user experience has rarely failed me.
+
+### My Professional Origins
+
+In my second year of university, I was trying to raise my GPA and was looking to sign up for a "Computer Usage" course. What I did was sign up for "Computer Science" by mistake, and the rest is history, ending with a Bachelor of Computer Science, with Honours and Co-op option.
+
+Beyond university, my career stayed in software development, with a heavy emphasis on open web technologies, like HTML, CSS, and JavaScript along with a healthy dose of Microsoft technologies, like .NET, SharePoint, and Microsoft Azure. I was a Microsoft MVP in the area of front-end web dev, formerly Internet Explorer (yes, really), for 9 years running, where I worked with various other professionals from around the world to help represent the revolution in web technologies as we see it today.
+
+### Outside the Office
+
+In the evening, I tend to learn about video games, my favourite entertainment medium. Although I play as much as I can, my focus for the past many years has been to learn the history, curate my own collection, and attempt to design and develop my own original video game creations.
+
+Cocoboko Studios is the embodiment of my passion and drive to make video games. Although there are no releases yet, the company is a work-in-progress and with some blood, sweat, and pixels one day I expect to see my ideas come to life.

--- a/src/content/pages/projects/index.md
+++ b/src/content/pages/projects/index.md
@@ -1,0 +1,40 @@
+---
+id: projects
+source: davidwesst.github.io
+docType: page
+slug: projects
+title: Projects
+summary: Active and retired projects by David Wesst.
+canonicalUrl: /projects/
+legacyUrls:
+  - /cocoboko-studios.html
+  - /cocoboko-studios/
+  - /remember-the-human.html
+  - /remember-the-human/
+taxonomy:
+  tags: []
+  categories: []
+---
+<section class="project-entry project-entry--active">
+
+## Cocoboko Studios
+
+<p class="project-status">Status: <span>Active</span></p>
+
+Named after an inside joke I had with my daughter when she was very young, Cocoboko Studios is a work-in-progress company where I attempt to bring my passion for video games to life.
+
+No releases just yet, but keep watching.
+
+</section>
+
+<section class="project-entry project-entry--archived">
+
+## Remember the Human
+
+<p class="project-status">Status: <span>Archived</span></p>
+
+Remember the Human was an AI podcast about people.
+
+The project is retired, but the episodes remain available on [Spotify](https://open.spotify.com/show/0ylqvEi3euRtIYR0n5T4V6), [YouTube](https://youtube.com/playlist?list=PLbTA1UhK0wKike9s5uPoxqTJ8HkdY9tzn&si=5UJNWa6ryG2xbKN7), and [Apple Podcasts](https://podcasts.apple.com/us/podcast/remember-the-human/id1697522062).
+
+</section>

--- a/src/page.11ty.js
+++ b/src/page.11ty.js
@@ -1,0 +1,50 @@
+import MarkdownIt from "markdown-it";
+
+const markdown = new MarkdownIt({ html: true });
+
+function escapeHtml(value = "") {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+export default class Page {
+  data() {
+    return {
+      pagination: {
+        data: "collections.pages",
+        size: 1,
+        alias: "contentPage",
+      },
+      layout: "base.webc",
+      eleventyComputed: {
+        title(data) {
+          return data.contentPage.title;
+        },
+      },
+      permalink(data) {
+        return data.contentPage.canonicalUrl;
+      },
+    };
+  }
+
+  render(data) {
+    const page = data.contentPage;
+    const summary = page.summary ? `<p class="lede">${escapeHtml(page.summary)}</p>` : "";
+
+    return `
+      <article class="page-detail">
+        <header class="page-header">
+          <p class="terminal-prompt">~/davidwesst ${escapeHtml(page.slug)}</p>
+          <h1>${escapeHtml(page.title)}</h1>
+          ${summary}
+        </header>
+        <div class="page-body">
+          ${markdown.render(page.body.markdown)}
+        </div>
+      </article>
+    `;
+  }
+}

--- a/tests/content-pipeline.test.mjs
+++ b/tests/content-pipeline.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { loadEvents, loadPosts, loadTalks } from "../src/_lib/content/loaders/local-content.js";
+import { loadEvents, loadPages, loadPosts, loadTalks } from "../src/_lib/content/loaders/local-content.js";
 import { normalizeContent } from "../src/_lib/content/normalize-content.js";
 import { normalizeTalks, validateRedirects } from "../src/_lib/content/normalize-talks.js";
 
@@ -14,7 +14,7 @@ function test(name, callback) {
 }
 
 function normalizeLocalContent() {
-  return normalizeContent({ talks: loadTalks(), events: loadEvents(), posts: loadPosts() });
+  return normalizeContent({ talks: loadTalks(), events: loadEvents(), posts: loadPosts(), pages: loadPages() });
 }
 
 function normalizeTalkContent() {
@@ -102,6 +102,16 @@ test("loads migrated post content from the new website", () => {
   assert.ok(posts.every((post) => post.nativePath.includes("src\\content\\posts") || post.nativePath.includes("src/content/posts")));
 });
 
+test("loads canonical page content from the new website", () => {
+  const pages = loadPages();
+
+  assert.equal(pages.length, 1);
+  assert.equal(pages[0].data.id, "about");
+  assert.equal(pages[0].data.docType, "page");
+  assert.equal(pages[0].data.canonicalUrl, "/about/");
+  assert.ok(pages[0].nativePath.includes("src\\content\\pages") || pages[0].nativePath.includes("src/content/pages"));
+});
+
 test("normalizes migrated posts into shared document records", () => {
   const { documents } = normalizeLocalContent();
   const posts = documents.filter((document) => ["blog", "gamelog", "dungeonlog"].includes(document.series));
@@ -110,6 +120,21 @@ test("normalizes migrated posts into shared document records", () => {
   assert.equal(posts.filter((post) => post.docType === "post").length, 138);
   assert.equal(posts.filter((post) => post.docType === "review").length, 14);
   assert.equal(posts.filter((post) => post.docType === "session").length, 12);
+});
+
+test("normalizes migrated pages into shared document records", () => {
+  const { documents, redirects } = normalizeLocalContent();
+  const page = documents.find((document) => document.id === "about");
+
+  assert.equal(page.docType, "page");
+  assert.equal(page.slug, "about");
+  assert.equal(page.canonicalUrl, "/about/");
+  assert.deepEqual(page.legacyUrls, ["/about.html"]);
+  assert.ok(
+    redirects.some(
+      (redirect) => redirect.from === "/about.html" && redirect.to === "/about/" && redirect.status === 301,
+    ),
+  );
 });
 
 test("preserves davidwesst.github.io blog URL structure", () => {

--- a/tests/content-pipeline.test.mjs
+++ b/tests/content-pipeline.test.mjs
@@ -104,12 +104,14 @@ test("loads migrated post content from the new website", () => {
 
 test("loads canonical page content from the new website", () => {
   const pages = loadPages();
+  const pageIds = pages.map((page) => page.data.id).sort();
 
-  assert.equal(pages.length, 1);
-  assert.equal(pages[0].data.id, "about");
-  assert.equal(pages[0].data.docType, "page");
-  assert.equal(pages[0].data.canonicalUrl, "/about/");
-  assert.ok(pages[0].nativePath.includes("src\\content\\pages") || pages[0].nativePath.includes("src/content/pages"));
+  assert.equal(pages.length, 2);
+  assert.deepEqual(pageIds, ["about", "projects"]);
+  assert.ok(pages.every((page) => page.data.docType === "page"));
+  assert.ok(pages.some((page) => page.data.canonicalUrl === "/about/"));
+  assert.ok(pages.some((page) => page.data.canonicalUrl === "/projects/"));
+  assert.ok(pages.every((page) => page.nativePath.includes("src\\content\\pages") || page.nativePath.includes("src/content/pages")));
 });
 
 test("normalizes migrated posts into shared document records", () => {
@@ -124,15 +126,33 @@ test("normalizes migrated posts into shared document records", () => {
 
 test("normalizes migrated pages into shared document records", () => {
   const { documents, redirects } = normalizeLocalContent();
-  const page = documents.find((document) => document.id === "about");
+  const about = documents.find((document) => document.id === "about");
+  const projects = documents.find((document) => document.id === "projects");
 
-  assert.equal(page.docType, "page");
-  assert.equal(page.slug, "about");
-  assert.equal(page.canonicalUrl, "/about/");
-  assert.deepEqual(page.legacyUrls, ["/about.html"]);
+  assert.equal(about.docType, "page");
+  assert.equal(about.slug, "about");
+  assert.equal(about.canonicalUrl, "/about/");
+  assert.deepEqual(about.legacyUrls, ["/about.html"]);
+  assert.equal(projects.docType, "page");
+  assert.equal(projects.slug, "projects");
+  assert.equal(projects.canonicalUrl, "/projects/");
+  assert.ok(projects.legacyUrls.includes("/cocoboko-studios.html"));
+  assert.ok(projects.legacyUrls.includes("/remember-the-human.html"));
   assert.ok(
     redirects.some(
       (redirect) => redirect.from === "/about.html" && redirect.to === "/about/" && redirect.status === 301,
+    ),
+  );
+  assert.ok(
+    redirects.some(
+      (redirect) =>
+        redirect.from === "/cocoboko-studios.html" && redirect.to === "/projects/" && redirect.status === 301,
+    ),
+  );
+  assert.ok(
+    redirects.some(
+      (redirect) =>
+        redirect.from === "/remember-the-human.html" && redirect.to === "/projects/" && redirect.status === 301,
     ),
   );
 });

--- a/tests/sitemap.spec.js
+++ b/tests/sitemap.spec.js
@@ -28,6 +28,16 @@ test("talk and event pages are generated from canonical data", async ({ request 
   await expect(request.get("/events/prairiedevcon-2022-regina/")).resolves.toBeOK();
 });
 
+test("about page is generated from canonical data", async ({ request }) => {
+  const response = await request.get("/about/");
+  await expect(response).toBeOK();
+
+  const html = await response.text();
+
+  expect(html).toContain("<h1>About</h1>");
+  expect(html).toContain("Hullo. My name is David Wesst");
+});
+
 test("site navigation is placed correctly on home and content pages", async ({ request }) => {
   const homeResponse = await request.get("/");
   await expect(homeResponse).toBeOK();
@@ -38,6 +48,12 @@ test("site navigation is placed correctly on home and content pages", async ({ r
   expect(homeHtml.indexOf("<h1><a href=\"/\">david.wes.st</a></h1>")).toBeLessThan(
     homeHtml.indexOf("<nav aria-label=\"Site\""),
   );
+  expect(homeHtml).toContain("<a href=\"/about/\">About</a>");
+  expect(homeHtml).not.toContain("<a href=\"/site-index/\">Site Index</a>");
+  expect(homeHtml).toContain("<a href=\"/about/\">about/</a>");
+  expect(homeHtml).toContain("<a href=\"/blog/?series=gamelog\">gamelog/</a>");
+  expect(homeHtml).toContain("<a href=\"/blog/?series=dungeonlog\">dungeonlog/</a>");
+  expect(homeHtml).not.toContain("<a href=\"/site-index/\">site-index/</a>");
 
   const talksResponse = await request.get("/talks/");
   await expect(talksResponse).toBeOK();
@@ -66,6 +82,15 @@ test("legacy typoed talk URL redirects directly to canonical talk URL", async ({
 
   expect(response.status()).toBe(301);
   expect(response.headers().location).toBe("/talks/consensus-in-the-chaos/");
+});
+
+test("legacy about URL redirects directly to canonical about URL", async ({ request }) => {
+  const response = await request.get("/about.html", {
+    maxRedirects: 0,
+  });
+
+  expect(response.status()).toBe(301);
+  expect(response.headers().location).toBe("/about/");
 });
 
 test("blog page emits filters, feed links, and client-side filtering script", async ({ request }) => {

--- a/tests/sitemap.spec.js
+++ b/tests/sitemap.spec.js
@@ -38,6 +38,21 @@ test("about page is generated from canonical data", async ({ request }) => {
   expect(html).toContain("Hullo. My name is David Wesst");
 });
 
+test("projects page is generated from canonical data", async ({ request }) => {
+  const response = await request.get("/projects/");
+  await expect(response).toBeOK();
+
+  const html = await response.text();
+
+  expect(html).toContain("<h1>Projects</h1>");
+  expect(html).toContain('<section class="project-entry project-entry--active">');
+  expect(html).toContain("<h2>Cocoboko Studios</h2>");
+  expect(html).toContain('Status: <span>Active</span>');
+  expect(html).toContain('<section class="project-entry project-entry--archived">');
+  expect(html).toContain("<h2>Remember the Human</h2>");
+  expect(html).toContain('Status: <span>Archived</span>');
+});
+
 test("site navigation is placed correctly on home and content pages", async ({ request }) => {
   const homeResponse = await request.get("/");
   await expect(homeResponse).toBeOK();
@@ -49,8 +64,13 @@ test("site navigation is placed correctly on home and content pages", async ({ r
     homeHtml.indexOf("<nav aria-label=\"Site\""),
   );
   expect(homeHtml).toContain("<a href=\"/about/\">About</a>");
+  expect(homeHtml).toContain("<a href=\"/projects/\">Projects</a>");
+  expect(homeHtml.indexOf("<a href=\"/events/\">Events</a>")).toBeLessThan(
+    homeHtml.indexOf("<a href=\"/projects/\">Projects</a>"),
+  );
   expect(homeHtml).not.toContain("<a href=\"/site-index/\">Site Index</a>");
   expect(homeHtml).toContain("<a href=\"/about/\">about/</a>");
+  expect(homeHtml).toContain("<a href=\"/projects/\">projects/</a>");
   expect(homeHtml).toContain("<a href=\"/blog/?series=gamelog\">gamelog/</a>");
   expect(homeHtml).toContain("<a href=\"/blog/?series=dungeonlog\">dungeonlog/</a>");
   expect(homeHtml).not.toContain("<a href=\"/site-index/\">site-index/</a>");
@@ -91,6 +111,20 @@ test("legacy about URL redirects directly to canonical about URL", async ({ requ
 
   expect(response.status()).toBe(301);
   expect(response.headers().location).toBe("/about/");
+});
+
+test("legacy project URLs redirect directly to canonical projects URL", async ({ request }) => {
+  const cocobokoResponse = await request.get("/cocoboko-studios.html", {
+    maxRedirects: 0,
+  });
+  const rememberResponse = await request.get("/remember-the-human.html", {
+    maxRedirects: 0,
+  });
+
+  expect(cocobokoResponse.status()).toBe(301);
+  expect(cocobokoResponse.headers().location).toBe("/projects/");
+  expect(rememberResponse.status()).toBe(301);
+  expect(rememberResponse.headers().location).toBe("/projects/");
 });
 
 test("blog page emits filters, feed links, and client-side filtering script", async ({ request }) => {


### PR DESCRIPTION
Migrating over remaining content from older sites.

- Added an about page
- Removed the site-index page from the global nav
- Added more pages to the home-intro component
