### PR TITLE
Add data-driven social media links to the home page

### DIFF
--- a/src/_data/socials.js
+++ b/src/_data/socials.js
@@ -1,0 +1,17 @@
+export default [
+  {
+    name: "GitHub",
+    url: "https://github.com/davidwesst",
+    icon: "fa-brands fa-github",
+  },
+  {
+    name: "LinkedIn",
+    url: "https://ca.linkedin.com/in/davidwesst",
+    icon: "fa-brands fa-linkedin",
+  },
+  {
+    name: "YouTube",
+    url: "https://youtube.com/davidwesst",
+    icon: "fa-brands fa-youtube",
+  },
+];

--- a/src/_includes/components/home-intro.webc
+++ b/src/_includes/components/home-intro.webc
@@ -28,6 +28,11 @@
   </ul>
 </nav>
 
+<section class="terminal-section" aria-labelledby="home-social-title">
+  <p class="terminal-prompt" id="home-social-title">~/davidwesst connect</p>
+  <social-links :@items="socials"></social-links>
+</section>
+
 <section class="terminal-section" aria-labelledby="latest-title">
   <p class="terminal-prompt" id="latest-title">~/davidwesst latest</p>
   <div class="content-list">

--- a/src/_includes/components/social-links.webc
+++ b/src/_includes/components/social-links.webc
@@ -1,0 +1,8 @@
+<ul webc:if="items && items.length" class="social-links">
+  <li webc:for="link of items">
+    <a :href="link.url" target="_blank" rel="noopener noreferrer">
+      <i :class="link.icon" aria-hidden="true"></i>
+      <span @text="link.name"></span>
+    </a>
+  </li>
+</ul>

--- a/src/_includes/layouts/base.webc
+++ b/src/_includes/layouts/base.webc
@@ -7,6 +7,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" :content="description || site.description">
+  <link webc:keep rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
   <link webc:keep rel="stylesheet" href="/assets/site.css">
   <title @text="title ? `${title} | ${site.title}` : site.title"></title>
 </head>

--- a/src/assets/site.css
+++ b/src/assets/site.css
@@ -272,6 +272,39 @@ time {
   color: var(--color-accent);
 }
 
+.social-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.social-links a {
+  align-items: center;
+  border: var(--line);
+  border-radius: var(--radius-sm);
+  color: var(--color-accent);
+  display: inline-flex;
+  font-family: var(--font-mono);
+  gap: var(--space-xs);
+  min-height: 2.75rem;
+  padding: var(--space-xs) var(--space-sm);
+  text-decoration: none;
+}
+
+.social-links a:hover {
+  border-color: currentColor;
+}
+
+.social-links i {
+  color: var(--color-text);
+  font-size: 1.1rem;
+  line-height: 1;
+  width: 1.25rem;
+}
+
 .content-list {
   display: grid;
   gap: 0;

--- a/src/index.webc
+++ b/src/index.webc
@@ -2,4 +2,4 @@
 title: Home
 layout: base.webc
 ---
-<home-intro :@documents="collections.documents"></home-intro>
+<home-intro :@documents="collections.documents" :@socials="socials"></home-intro>

--- a/tests/sitemap.spec.js
+++ b/tests/sitemap.spec.js
@@ -48,6 +48,20 @@ test("site navigation is placed correctly on home and content pages", async ({ r
   expect(talksHtml.indexOf("<nav aria-label=\"Site\"")).toBeLessThan(talksHtml.indexOf("<h1>Talks</h1>"));
 });
 
+test("home page renders social links from site data", async ({ request }) => {
+  const response = await request.get("/");
+  await expect(response).toBeOK();
+  const html = await response.text();
+
+  expect(html).toContain("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css");
+  expect(html).toContain('<a href="https://github.com/davidwesst" target="_blank" rel="noopener noreferrer">');
+  expect(html).toContain('class="fa-brands fa-github"');
+  expect(html).toContain('<a href="https://ca.linkedin.com/in/davidwesst" target="_blank" rel="noopener noreferrer">');
+  expect(html).toContain('class="fa-brands fa-linkedin"');
+  expect(html).toContain('<a href="https://youtube.com/davidwesst" target="_blank" rel="noopener noreferrer">');
+  expect(html).toContain('class="fa-brands fa-youtube"');
+});
+
 test("site index excludes data-generated detail pages", async ({ request }) => {
   const response = await request.get("/site-index/");
   await expect(response).toBeOK();


### PR DESCRIPTION
## Summary
- Added a site data module for David Wesst's social profiles with platform name, URL, and Font Awesome icon metadata
- Rendered the links as a new home page section that opens each profile in a new tab
- Added Font Awesome styling and a focused Playwright regression test for the home page output

## Testing
- `npm test` passed, including unit checks, Eleventy build, and Playwright coverage for the new social links