### PR TITLE
Normalize game play metadata, derive list summaries, and show platform pills in blog list

### DIFF
--- a/src/_lib/content/normalize-content.js
+++ b/src/_lib/content/normalize-content.js
@@ -4,6 +4,14 @@ import { normalizeUrlPath } from "./slug.js";
 const SOURCE = "website";
 const POST_SERIES = new Set(["blog", "gamelog", "dungeonlog"]);
 
+const PLATFORM_ALIASES = [
+  { pattern: /steam\s*deck|steamdeck/i, normalized: "steam-deck", label: "Steam Deck", icon: "🎮" },
+  { pattern: /steam/i, normalized: "steam", label: "Steam", icon: "🖥️" },
+  { pattern: /xbox\s*series\s*x/i, normalized: "xbox-series-x", label: "Xbox Series X", icon: "🟩" },
+  { pattern: /xbox/i, normalized: "xbox", label: "Xbox", icon: "🟩" },
+  { pattern: /pc|windows/i, normalized: "pc", label: "PC", icon: "🖥️" },
+];
+
 function normalizeLegacyUrl(value) {
   const url = String(value);
 
@@ -80,17 +88,96 @@ function normalizeReview(raw = {}) {
     return undefined;
   }
 
+  const normalizedPlay =
+    play && (play.platform || play.startedOn || play.started_on || play.completedOn || play.completed_on)
+      ? normalizePlayMeta(play)
+      : undefined;
+
   return {
     subjectIds: review.subjectIds || raw.game_ids,
-    play: play
-      ? {
-          startedOn: normalizeDate(play.startedOn || play.started_on),
-          completedOn: normalizeDate(play.completedOn || play.completed_on),
-          platform: play.platform,
-        }
-      : undefined,
+    play: normalizedPlay,
     rating: review.rating || raw.rating,
   };
+}
+
+function normalizePlatformEntry(value) {
+  const entry = String(value || "").trim();
+  if (!entry) {
+    return undefined;
+  }
+
+  for (const alias of PLATFORM_ALIASES) {
+    if (alias.pattern.test(entry)) {
+      return {
+        key: alias.normalized,
+        label: alias.label,
+        icon: alias.icon,
+      };
+    }
+  }
+
+  return {
+    key: entry.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, ""),
+    label: entry,
+    icon: "🎮",
+  };
+}
+
+function normalizePlayMeta(play = {}) {
+  const platformRaw = play.platform;
+  const platformEntries = String(platformRaw || "")
+    .split(/[\/,+]/)
+    .map((value) => normalizePlatformEntry(value))
+    .filter(Boolean);
+  const uniquePlatforms = [...new Map(platformEntries.map((platform) => [platform.key, platform])).values()];
+
+  return removeUndefined({
+    startedOn: normalizeDate(play.startedOn || play.started_on),
+    completedOn: normalizeDate(play.completedOn || play.completed_on),
+    platform: uniquePlatforms.map((platform) => platform.label).join(" / ") || undefined,
+    platforms: uniquePlatforms,
+  });
+}
+
+function extractFirstParagraph(markdown = "") {
+  const lines = String(markdown).split(/\r?\n/);
+  const paragraphLines = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (!trimmed) {
+      if (paragraphLines.length) {
+        break;
+      }
+      continue;
+    }
+
+    if (/^(#|!\[|\[.+\]:|>|```|---|\*\s|\d+\.)/.test(trimmed)) {
+      if (paragraphLines.length) {
+        break;
+      }
+      continue;
+    }
+
+    paragraphLines.push(trimmed);
+  }
+
+  const paragraph = paragraphLines.join(" ").replace(/\[(.*?)\]\((.*?)\)/g, "$1").trim();
+  return paragraph || undefined;
+}
+
+function makeListBlurb(rawSummary, markdown, maxLength = 220) {
+  const source = String(rawSummary || "").trim() || extractFirstParagraph(markdown) || "";
+  if (!source) {
+    return undefined;
+  }
+
+  if (source.length <= maxLength) {
+    return source;
+  }
+
+  return `${source.slice(0, maxLength).replace(/\s+\S*$/, "").trimEnd()}…`;
 }
 
 function removeUndefined(value) {
@@ -124,7 +211,7 @@ function normalizeTalk(raw) {
     series: raw.data.series || "talks",
     slug,
     title: raw.data.title,
-    summary: raw.data.summary,
+    summary: makeListBlurb(raw.data.summary, raw.body),
     body: {
       markdown: raw.body,
     },

--- a/src/_lib/content/normalize-content.js
+++ b/src/_lib/content/normalize-content.js
@@ -139,7 +139,25 @@ function normalizePlayMeta(play = {}) {
   });
 }
 
-function extractFirstParagraph(markdown = "") {
+function isTitleIntro(paragraph, title) {
+  if (!title) {
+    return false;
+  }
+
+  const normalizedParagraph = paragraph.toLowerCase();
+  const normalizedTitle = String(title).trim().toLowerCase();
+
+  return normalizedParagraph.startsWith(`${normalizedTitle} is `);
+}
+
+function cleanParagraph(markdown) {
+  return markdown
+    .join(" ")
+    .replace(/\[(.*?)\]\((.*?)\)/g, "$1")
+    .trim();
+}
+
+function extractFirstParagraph(markdown = "", { title } = {}) {
   const lines = String(markdown).split(/\r?\n/);
   const paragraphLines = [];
 
@@ -148,14 +166,22 @@ function extractFirstParagraph(markdown = "") {
 
     if (!trimmed) {
       if (paragraphLines.length) {
-        break;
+        const paragraph = cleanParagraph(paragraphLines);
+        if (paragraph && !isTitleIntro(paragraph, title)) {
+          return paragraph;
+        }
+        paragraphLines.length = 0;
       }
       continue;
     }
 
     if (/^(#|!\[|\[.+\]:|>|```|---|\*\s|\d+\.)/.test(trimmed)) {
       if (paragraphLines.length) {
-        break;
+        const paragraph = cleanParagraph(paragraphLines);
+        if (paragraph && !isTitleIntro(paragraph, title)) {
+          return paragraph;
+        }
+        paragraphLines.length = 0;
       }
       continue;
     }
@@ -163,12 +189,12 @@ function extractFirstParagraph(markdown = "") {
     paragraphLines.push(trimmed);
   }
 
-  const paragraph = paragraphLines.join(" ").replace(/\[(.*?)\]\((.*?)\)/g, "$1").trim();
+  const paragraph = cleanParagraph(paragraphLines);
   return paragraph || undefined;
 }
 
-function makeListBlurb(rawSummary, markdown, maxLength = 220) {
-  const source = String(rawSummary || "").trim() || extractFirstParagraph(markdown) || "";
+function makeListBlurb(rawSummary, markdown, maxLength = 220, options = {}) {
+  const source = String(rawSummary || "").trim() || extractFirstParagraph(markdown, options) || "";
   if (!source) {
     return undefined;
   }
@@ -255,7 +281,7 @@ function normalizePost(raw) {
     series,
     slug,
     title: raw.data.title,
-    summary: raw.data.summary,
+    summary: makeListBlurb(raw.data.summary, raw.body, 220, { title: raw.data.title }),
     body: {
       markdown: raw.body,
     },

--- a/src/assets/site.css
+++ b/src/assets/site.css
@@ -464,6 +464,11 @@ time {
   min-width: 0;
 }
 
+.post-list__date,
+.post-list__completion {
+  white-space: nowrap;
+}
+
 .post-list__game-meta {
   align-items: center;
   color: var(--color-muted);

--- a/src/assets/site.css
+++ b/src/assets/site.css
@@ -464,6 +464,36 @@ time {
   min-width: 0;
 }
 
+.post-list__game-meta {
+  align-items: center;
+  color: var(--color-muted);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs) var(--space-sm);
+  margin: 0;
+}
+
+.post-list__platforms {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--space-2xs);
+}
+
+.post-list__platform-pill {
+  align-items: center;
+  background: var(--color-bg-elevated);
+  border: var(--line);
+  border-radius: var(--radius-sm);
+  display: inline-flex;
+  gap: 0.35rem;
+  padding: 0.1rem 0.4rem;
+}
+
+.post-list__platform-icon {
+  font-size: 0.9rem;
+  line-height: 1;
+}
+
 .post-list--default .post-list__item[data-series="gamelog"],
 .post-list--default .post-list__item[data-series="dungeonlog"],
 .post-list__item[hidden] {

--- a/src/blog/index.webc
+++ b/src/blog/index.webc
@@ -78,7 +78,9 @@ layout: base.webc
     <div class="post-list__content">
       <p class="post-list__series" @text="post.series"></p>
       <h2><a :href="post.canonicalUrl" @text="post.title"></a></h2>
-      <p webc:if="post.dates && post.dates.published" @text="post.dates.published"></p>
+      <p webc:if="post.dates && post.dates.published" class="post-list__date">
+        <time :datetime="post.dates.published" @text="post.dates.published"></time>
+      </p>
       <p webc:if="post.summary" @text="post.summary"></p>
       <p webc:if="post.series === 'gamelog' && post.review && post.review.play" class="post-list__game-meta">
         <span webc:if="post.review.play.platforms && post.review.play.platforms.length" class="post-list__platforms">
@@ -87,7 +89,7 @@ layout: base.webc
             <span @text="platform.label"></span>
           </span>
         </span>
-        <span webc:if="formatGameCompletionDate(post)">Completed <span @text="formatGameCompletionDate(post)"></span></span>
+        <span webc:if="formatGameCompletionDate(post)" class="post-list__completion">Completed <span @text="formatGameCompletionDate(post)"></span></span>
       </p>
     </div>
   </article>

--- a/src/blog/index.webc
+++ b/src/blog/index.webc
@@ -18,6 +18,24 @@ layout: base.webc
       dungeonlog: "Default dungeonlog post thumbnail",
     }[series] || "Default post thumbnail";
   }
+
+  function formatGameCompletionDate(post) {
+    const completedOn = post?.review?.play?.completedOn;
+    if (!completedOn) {
+      return undefined;
+    }
+
+    const parsed = new Date(`${completedOn}T00:00:00Z`);
+    if (Number.isNaN(parsed.valueOf())) {
+      return completedOn;
+    }
+
+    return new Intl.DateTimeFormat("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    }).format(parsed);
+  }
 </script>
 
 <header class="page-header">
@@ -62,6 +80,15 @@ layout: base.webc
       <h2><a :href="post.canonicalUrl" @text="post.title"></a></h2>
       <p webc:if="post.dates && post.dates.published" @text="post.dates.published"></p>
       <p webc:if="post.summary" @text="post.summary"></p>
+      <p webc:if="post.series === 'gamelog' && post.review && post.review.play" class="post-list__game-meta">
+        <span webc:if="post.review.play.platforms && post.review.play.platforms.length" class="post-list__platforms">
+          <span webc:for="platform of post.review.play.platforms" class="post-list__platform-pill">
+            <span class="post-list__platform-icon" aria-hidden="true" @text="platform.icon"></span>
+            <span @text="platform.label"></span>
+          </span>
+        </span>
+        <span webc:if="formatGameCompletionDate(post)">Completed <span @text="formatGameCompletionDate(post)"></span></span>
+      </p>
     </div>
   </article>
 </section>

--- a/tests/content-pipeline.test.mjs
+++ b/tests/content-pipeline.test.mjs
@@ -199,8 +199,16 @@ test("keeps gamelog supplemental data in review metadata", () => {
   const post = documents.find((document) => document.id === "gamelog/blue-prince");
 
   assert.equal(post.review.subjectIds.igdb_id, 149657);
-  assert.equal(post.review.play.platform, "XBox Series X");
+  assert.equal(post.review.play.platform, "Xbox Series X");
+  assert.equal(post.review.play.platforms[0].key, "xbox-series-x");
   assert.equal(post.review.rating.overall, 3);
+});
+
+test("derives post summaries from the first markdown paragraph when missing", () => {
+  const { documents } = normalizeLocalContent();
+  const post = documents.find((document) => document.id === "gamelog/tr-49");
+
+  assert.ok(post.summary.startsWith("This game is a solid attempt at a narrative deduction game"));
 });
 
 test("keeps gamelog front matter focused on canonical fields", () => {


### PR DESCRIPTION
### Motivation
- Standardize and normalize play metadata (platforms, dates) for review/gamelog posts so downstream consumers have consistent keys and labels.
- Derive concise list summaries from markdown when front-matter `summary` is missing to improve list display consistency.
- Surface platform and completion metadata in the blog index UI for gamelog posts with compact styling.

### Description
- Added `PLATFORM_ALIASES`, `normalizePlatformEntry`, and `normalizePlayMeta` to normalize platform names into structured `platforms` (key/label/icon) and a combined `platform` string, and to normalize play dates in `src/_lib/content/normalize-content.js`.
- Reworked `normalizeReview` to use the new play normalization and added `extractFirstParagraph` and `makeListBlurb` to derive short summaries from markdown when needed, and used `makeListBlurb` for talk summaries.
- Updated blog list UI in `src/blog/index.webc` to render platform pills and a formatted completion date for `gamelog` posts, and added `formatGameCompletionDate` helper for display.
- Added CSS rules in `src/assets/site.css` to style the platform pills and game meta in the post list.
- Updated tests in `tests/content-pipeline.test.mjs` to expect normalized platform keys/labels and added a test asserting derived summaries from the first markdown paragraph.

### Testing
- Ran the repository test suite with `npm test` and all tests passed successfully. 
- Updated the `keeps gamelog supplemental data in review metadata` test to assert normalized platform values and added `derives post summaries from the first markdown paragraph when missing` which passed. 
- Existing redirect and front-matter canonicalization tests were re-run and remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13d80108588330a1b1d8292f687201)