### PR TITLE
Avoid deprecated Application Insights unload listener

### DIFF
--- a/src/_lib/telemetry-policy.js
+++ b/src/_lib/telemetry-policy.js
@@ -102,6 +102,7 @@ export function createApplicationInsightsConfig(connectionString) {
     disableCorrelationHeaders: true,
     disableExceptionTracking: false,
     disableFetchTracking: false,
+    disablePageUnloadEvents: ["unload"],
     enableAjaxErrorStatusText: false,
     enableAutoRouteTracking: false,
     enableCorsCorrelation: false,

--- a/tests/telemetry.test.js
+++ b/tests/telemetry.test.js
@@ -57,6 +57,7 @@ test("Application Insights configuration permits only operational telemetry", ()
   assert.equal(config.enableUnhandledPromiseRejectionTracking, true);
   assert.equal(config.disableAjaxTracking, false);
   assert.equal(config.disableFetchTracking, false);
+  assert.deepEqual(config.disablePageUnloadEvents, ["unload"]);
   assert.equal(config.enableRequestHeaderTracking, false);
   assert.equal(config.enableResponseHeaderTracking, false);
   assert.equal(config.disableCorrelationHeaders, true);


### PR DESCRIPTION
### Motivation

- Vivaldi warns about deprecated unload event listeners because the bundled Application Insights SDK registers legacy unload handlers by default. 
- The intent is to remove only the deprecated `unload` listener while retaining modern page-lifecycle handling (`pagehide`, `visibilitychange`) and preserving the repository's separation of telemetry policy from presentation.
- This change follows the repository solution design and introduces no design conflicts with `docs/solution-design.md`.

### Description

- Add `disablePageUnloadEvents: ["unload"]` to `createApplicationInsightsConfig` in `src/_lib/telemetry-policy.js` so the SDK will not register the deprecated `unload` handler. 
- Add an assertion in `tests/telemetry.test.js` to lock the lifecycle configuration and prevent regressions by asserting `config.disablePageUnloadEvents` equals `["unload"]`.
- Keep the change confined to the centralized telemetry policy so presentation components and bundling remain unchanged.

### Testing

- `pnpm run build` was executed and completed successfully with telemetry disabled for this non-production branch. 
- `node --test tests/*.test.js` ran and the unit tests (including the new assertion) passed. 
- `pnpm test` completed its build but the repository-level content-integrity check failed due to an unrelated asset hash mismatch in `src/content/posts/articles/a-solo-gamejam-experience-ld47/New_Ludum_Dare_Logo.png`, so the overall `pnpm test` command exited non-zero for reasons unrelated to the telemetry change. 
- `git diff --check` was run and reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a83f62931b483308dd0259bbef6ed46)