### PR TITLE
feature: connect related and sequential content

### DIFF
--- a/docs/solution-design.md
+++ b/docs/solution-design.md
@@ -61,6 +61,8 @@ The base shell contains only minimal integration points for telemetry. Source-sp
 
 Canonical pages derive descriptions, canonical URLs, Open Graph fields, preview images, publication metadata, and Schema.org JSON-LD through a shared metadata preparation layer. Preview images prefer authored banners, then normalized gamelog artwork, then the repository-owned default social image. Canonical content is exposed through a generated sitemap, robots policy, and Atom feeds for the combined blog and each content family; redirect and noindex compatibility pages are excluded.
 
+Post and talk detail pages expose deterministic related content ranked by shared topics, same-family membership, recency, and canonical URL. They also provide chronological navigation within the current family plus archive and topic pathways.
+
 ## Operational telemetry
 
 The `main` branch is the production site. Its build requires `APPLICATIONINSIGHTS_CONNECTION_STRING` and fails before rendering when that value is missing or invalid. Other branches do not generate or reference the telemetry asset, even if the connection string is present, so development and pull-request activity cannot contaminate production telemetry. Eleventy's development server does not reference telemetry on any branch; its built-in run mode distinguishes serving from a production build without a separate environment flag. Build context is derived from `GITHUB_REF_NAME` when available and otherwise from the current Git branch.

--- a/src/_data/eleventyComputed.js
+++ b/src/_data/eleventyComputed.js
@@ -1,5 +1,7 @@
 import { preparePageMetadata } from "../_lib/page-metadata.js";
+import { prepareContentNavigation } from "../_lib/content-navigation.js";
 
 export default {
   pageMetadata: (data) => preparePageMetadata(data),
+  contentNavigation: (data) => ["article", "gamelog", "dungeonlog", "talk"].includes(data.type) ? prepareContentNavigation([...(data.collections?.posts || []), ...(data.collections?.talks || [])], data.page.url, data.type, data.topics) : null,
 };

--- a/src/_data/related.js
+++ b/src/_data/related.js
@@ -1,0 +1,2 @@
+import { prepareContentNavigation } from "../_lib/content-navigation.js";
+export default { prepare: prepareContentNavigation };

--- a/src/_includes/components/content-navigation.webc
+++ b/src/_includes/components/content-navigation.webc
@@ -7,5 +7,5 @@
     <h2 id="related-heading" class="text-3xl font-black">Related content</h2>
     <ol class="mt-6 grid list-none gap-6 p-0 md:grid-cols-3"><li webc:for="item of model.related"><post-card :@item="item" :@site="site" :@featured="false" :@description="item.data.summary"></post-card></li></ol>
   </section>
-  <p class="mt-8 text-center"><a class="font-bold text-teal-700" :href="model.archiveUrl">Explore the complete archive</a><span webc:if="model.topics.length"> · <a href="/topics/">Browse topics</a></span></p>
+  <p class="mt-8 text-center"><a class="font-bold text-teal-700" :href="model.archiveUrl">Explore the complete <span @text="model.type"></span> archive</a><span webc:if="model.topics.length"> · <a href="/topics/">Browse topics</a></span></p>
 </aside>

--- a/src/_includes/components/content-navigation.webc
+++ b/src/_includes/components/content-navigation.webc
@@ -1,0 +1,11 @@
+<aside class="mx-auto mt-12 max-w-4xl" aria-label="Continue exploring">
+  <nav class="flex flex-wrap justify-between gap-4 border-y border-slate-300 py-5" aria-label="Previous and next content">
+    <a webc:if="model.previous" class="font-bold text-teal-700" :href="model.previous.url">← <span @text="model.previous.data.title"></span></a>
+    <a webc:if="model.next" class="ml-auto font-bold text-teal-700" :href="model.next.url"><span @text="model.next.data.title"></span> →</a>
+  </nav>
+  <section webc:if="model.related.length" class="mt-10" aria-labelledby="related-heading">
+    <h2 id="related-heading" class="text-3xl font-black">Related content</h2>
+    <ol class="mt-6 grid list-none gap-6 p-0 md:grid-cols-3"><li webc:for="item of model.related"><post-card :@item="item" :@site="site" :@featured="false" :@description="item.data.summary"></post-card></li></ol>
+  </section>
+  <p class="mt-8 text-center"><a class="font-bold text-teal-700" :href="model.archiveUrl">Explore the complete archive</a><span webc:if="model.topics.length"> · <a href="/topics/">Browse topics</a></span></p>
+</aside>

--- a/src/_includes/layouts/post.webc
+++ b/src/_includes/layouts/post.webc
@@ -25,4 +25,5 @@ layout: base.webc
       Artwork and game details data from <a class="font-semibold text-teal-700 hover:text-teal-900" href="https://www.igdb.com/">IGDB.com</a>.
     </footer>
   </div>
+  <content-navigation :@model="contentNavigation" :@site="site"></content-navigation>
 </article>

--- a/src/_includes/layouts/talk.webc
+++ b/src/_includes/layouts/talk.webc
@@ -21,4 +21,5 @@ layout: base.webc
     <section webc:if="content" class="prose-content" aria-label="Talk description" @raw="content"></section>
     <talk-details :@custom-data="customData"></talk-details>
   </div>
+  <content-navigation :@model="contentNavigation" :@site="site"></content-navigation>
 </article>

--- a/src/_lib/content-navigation.js
+++ b/src/_lib/content-navigation.js
@@ -5,5 +5,5 @@ export function prepareContentNavigation(items, currentUrl, type, topics = [], l
   const related = canonical.filter((item) => item.url !== currentUrl).map((item) => ({ item, shared: sharedTopicCount(topics, item.data.topics) })).filter(({ shared }) => shared > 0).sort((left, right) => right.shared - left.shared || Number(right.item.data.type === type) - Number(left.item.data.type === type) || right.item.date - left.item.date || left.item.url.localeCompare(right.item.url)).slice(0, limit).map(({ item }) => item);
   const family = canonical.filter((item) => item.data.type === type).sort((left, right) => left.date - right.date || left.url.localeCompare(right.url));
   const index = family.findIndex((item) => item.url === currentUrl);
-  return { related, previous: index > 0 ? family[index - 1] : null, next: index >= 0 && index < family.length - 1 ? family[index + 1] : null, archiveUrl: ARCHIVES[type] || "/blog/", topics };
+  return { related, previous: index > 0 ? family[index - 1] : null, next: index >= 0 && index < family.length - 1 ? family[index + 1] : null, archiveUrl: ARCHIVES[type] || "/blog/", type, topics };
 }

--- a/src/_lib/content-navigation.js
+++ b/src/_lib/content-navigation.js
@@ -1,0 +1,9 @@
+const ARCHIVES = { article: "/blog/articles/", gamelog: "/blog/gamelogs/", dungeonlog: "/blog/dungeonlogs/", talk: "/talks/" };
+function sharedTopicCount(left = [], right = []) { const rightSet = new Set(right.map((topic) => topic.toLowerCase())); return new Set(left.map((topic) => topic.toLowerCase()).filter((topic) => rightSet.has(topic))).size; }
+export function prepareContentNavigation(items, currentUrl, type, topics = [], limit = 3) {
+  const canonical = [...(items || [])].filter((item) => item.url && !item.data?.robots && !item.data?.targetUrl);
+  const related = canonical.filter((item) => item.url !== currentUrl).map((item) => ({ item, shared: sharedTopicCount(topics, item.data.topics) })).filter(({ shared }) => shared > 0).sort((left, right) => right.shared - left.shared || Number(right.item.data.type === type) - Number(left.item.data.type === type) || right.item.date - left.item.date || left.item.url.localeCompare(right.item.url)).slice(0, limit).map(({ item }) => item);
+  const family = canonical.filter((item) => item.data.type === type).sort((left, right) => left.date - right.date || left.url.localeCompare(right.url));
+  const index = family.findIndex((item) => item.url === currentUrl);
+  return { related, previous: index > 0 ? family[index - 1] : null, next: index >= 0 && index < family.length - 1 ? family[index + 1] : null, archiveUrl: ARCHIVES[type] || "/blog/", topics };
+}

--- a/tests/site.test.js
+++ b/tests/site.test.js
@@ -6,6 +6,7 @@ import { load } from "cheerio";
 import matter from "gray-matter";
 import { getPostDescription, prepareHomeContent } from "../src/_lib/home-content.js";
 import { preparePageMetadata } from "../src/_lib/page-metadata.js";
+import { prepareContentNavigation } from "../src/_lib/content-navigation.js";
 import site from "../src/_data/site.js";
 import { IGDB_CACHE_SCHEMA_VERSION, hasCachedImages, readIgdbManifest } from "../lib/igdb.js";
 import { telemetryBuildConfig } from "../lib/telemetry-build.js";
@@ -326,4 +327,17 @@ test("sitemap, robots, and feeds expose canonical content", async () => {
     assert.match(feed, /<author><name>David Wesst<\/name>/);
     assert.match(feed, new RegExp(`<id>https://david\\.wes\\.st/${file.replaceAll(".", "\\.")}</id>`));
   }
+});
+
+test("content navigation ranks topics and provides family sequence", () => {
+  const items = [
+    { url: "/older/", date: new Date("2024-01-01"), data: { type: "article", topics: ["web"] } },
+    { url: "/current/", date: new Date("2025-01-01"), data: { type: "article", topics: ["web", "games"] } },
+    { url: "/talk/", date: new Date("2026-01-01"), data: { type: "talk", topics: ["web", "games"] } },
+    { url: "/newer/", date: new Date("2026-02-01"), data: { type: "article", topics: ["games"] } },
+  ];
+  const result = prepareContentNavigation(items, "/current/", "article", ["web", "games"]);
+  assert.deepEqual(result.related.map((item) => item.url), ["/talk/", "/newer/", "/older/"]);
+  assert.equal(result.previous.url, "/older/");
+  assert.equal(result.next.url, "/newer/");
 });

--- a/tests/site.test.js
+++ b/tests/site.test.js
@@ -196,6 +196,21 @@ test("representative post types render normalized data", async () => {
   assert.ok(dungeonlog("figure img").length);
 });
 
+test("detail pages link to their type-specific archives", async () => {
+  const cases = [
+    ["blog/from-11ty-to-wordpress-and-back-again/index.html", "article", "/blog/articles/"],
+    ["blog/clair-obscur-expedition-33/index.html", "gamelog", "/blog/gamelogs/"],
+    ["blog/2026-03-16/index.html", "dungeonlog", "/blog/dungeonlogs/"],
+    ["talks/no-mission-impossible/index.html", "talk", "/talks/"],
+  ];
+
+  for (const [path, type, archiveUrl] of cases) {
+    const $ = await page(path);
+    const archive = $(`a[href='${archiveUrl}']`).filter((_, element) => $(element).text().includes("Explore the complete"));
+    assert.equal(archive.text().replace(/\s+/g, " ").trim(), `Explore the complete ${type} archive`);
+  }
+});
+
 test("post visuals use banners or accessible type-specific fallbacks", async () => {
   const article = await page("blog/i-miss-blogging/index.html");
   assert.equal(article("figure [role=img]").attr("aria-label"), "Article placeholder image");


### PR DESCRIPTION
## What changed

- Added normalized topic-based related-content ranking.
- Added previous and next navigation within each content family.
- Added archive and topic pathways to post and talk detail pages.
- Omitted related sections cleanly when no candidates exist.

## Why

Landing on one page should lead readers naturally into more of the existing archive instead of ending the visit.

## Impact

All four content families gain deterministic onward navigation without new authored fields.

## Validation

- `pnpm test` — 35 tests passed
- Content integrity passed for 185 documents, 197 assets, 258 topics, and 209 legacy URLs

## Acceptance checklist

- [x] Ranking follows shared topics, family, recency, and URL tie-break order.
- [x] Current, redirect, and compatibility entries are excluded.
- [x] Previous and next navigation stays within the family.
- [x] Related content is capped at three items.

## Stack

Depends on #38, which depends on #36.