### PR TITLE
feature: add content sharing and campaign link tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ A minimal Eleventy site using Markdown for content, WebC for components and layo
 - `pnpm start` delegates to `pnpm dev`.
 - `pnpm build` creates the production site in `_site`.
 - `pnpm test` performs a production build, validates content integrity, and runs the Node test suite.
+- `pnpm campaign:links <canonical-url> [campaign]` emits validated YouTube, Bluesky, LinkedIn, and Instagram campaign URLs for a page in the current `_site` build. Visitor-facing share links always use the untracked canonical URL.
+
+## Content distribution
+
+- YouTube descriptions should link to the corresponding article, gamelog, or talk.
+- Bluesky posts should use a short observation or excerpt that leads to the complete canonical page.
+- LinkedIn should promote relevant professional articles and talks.
+- Instagram should direct suitable game or visual posts to the canonical page.
 
 ## IGDB game data
 

--- a/docs/solution-design.md
+++ b/docs/solution-design.md
@@ -61,7 +61,7 @@ The base shell contains only minimal integration points for telemetry. Source-sp
 
 Canonical pages derive descriptions, canonical URLs, Open Graph fields, preview images, publication metadata, and Schema.org JSON-LD through a shared metadata preparation layer. Preview images prefer authored banners, then normalized gamelog artwork, then the repository-owned default social image. Canonical content is exposed through a generated sitemap, robots policy, and Atom feeds for the combined blog and each content family; redirect and noindex compatibility pages are excluded.
 
-Post and talk detail pages expose deterministic related content ranked by shared topics, same-family membership, recency, and canonical URL. They also provide chronological navigation within the current family plus archive and topic pathways.
+Post and talk detail pages expose deterministic related content ranked by shared topics, same-family membership, recency, and canonical URL. They also provide chronological navigation within the current family plus archive and topic pathways. Detail pages provide progressively enhanced native sharing, canonical-link copying, and direct Bluesky, LinkedIn, and email links. Visitor sharing never adds campaign parameters; a development-only generator validates built pages and emits consistent platform campaign URLs for owner-published distribution.
 
 ## Operational telemetry
 

--- a/lib/campaign-links.js
+++ b/lib/campaign-links.js
@@ -1,0 +1,9 @@
+export const CAMPAIGN_SOURCES = new Set(["youtube", "bluesky", "linkedin", "instagram"]);
+export function campaignUrl(input, source, campaign, siteUrl = "https://david.wes.st") {
+  if (!CAMPAIGN_SOURCES.has(source)) throw new Error(`Unsupported campaign source: ${source}`);
+  if (!campaign?.trim()) throw new Error("Campaign is required");
+  const url = new URL(input, siteUrl);
+  if (url.origin !== new URL(siteUrl).origin || url.hash || url.pathname.startsWith("/categories/") || url.pathname.startsWith("/legacy/")) throw new Error("Only canonical published site URLs are supported");
+  url.search = ""; url.searchParams.set("utm_source", source); url.searchParams.set("utm_medium", "social"); url.searchParams.set("utm_campaign", campaign.trim());
+  return url.href;
+}

--- a/lib/campaign-links.js
+++ b/lib/campaign-links.js
@@ -1,9 +1,13 @@
 export const CAMPAIGN_SOURCES = new Set(["youtube", "bluesky", "linkedin", "instagram"]);
+export function canonicalPageUrl(input, siteUrl = "https://david.wes.st") {
+  const url = new URL(input, siteUrl);
+  if (url.origin !== new URL(siteUrl).origin || url.search || url.hash || !url.pathname.endsWith("/") || /^\/(categories|legacy)(?:\/|$)/.test(url.pathname)) throw new Error("Only canonical published site page URLs are supported");
+  return url;
+}
 export function campaignUrl(input, source, campaign, siteUrl = "https://david.wes.st") {
   if (!CAMPAIGN_SOURCES.has(source)) throw new Error(`Unsupported campaign source: ${source}`);
   if (!campaign?.trim()) throw new Error("Campaign is required");
-  const url = new URL(input, siteUrl);
-  if (url.origin !== new URL(siteUrl).origin || url.hash || url.pathname.startsWith("/categories/") || url.pathname.startsWith("/legacy/")) throw new Error("Only canonical published site URLs are supported");
-  url.search = ""; url.searchParams.set("utm_source", source); url.searchParams.set("utm_medium", "social"); url.searchParams.set("utm_campaign", campaign.trim());
+  const url = canonicalPageUrl(input, siteUrl);
+  url.searchParams.set("utm_source", source); url.searchParams.set("utm_medium", "social"); url.searchParams.set("utm_campaign", campaign.trim());
   return url.href;
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prepare:igdb:local": "node tools/prepare-igdb-interactive.mjs",
     "prepare:telemetry": "node tools/prepare-telemetry.mjs",
     "check:content": "node tools/check-content.mjs",
+    "campaign:links": "node tools/campaign-links.mjs",
     "build": "pnpm run clean && pnpm run prepare:igdb && pnpm run prepare:telemetry && pnpm run build:site && pnpm run build:css",
     "build:site": "eleventy",
     "build:css": "tailwindcss -i ./src/styles/main.css -o ./_site/assets/main.css --minify",

--- a/src/_includes/components/share-content.webc
+++ b/src/_includes/components/share-content.webc
@@ -1,0 +1,14 @@
+<script webc:setup>const encodedUrl = encodeURIComponent(url); const encodedTitle = encodeURIComponent(title);</script>
+<section class="mx-auto mt-8 max-w-4xl rounded-lg border border-slate-300 bg-white p-5" aria-labelledby="share-heading" :data-share-url="url" :data-share-title="title">
+  <h2 id="share-heading" class="text-xl font-black">Share this</h2>
+  <div class="mt-4 flex flex-wrap gap-3">
+    <button class="native-share hidden rounded bg-teal-700 px-4 py-2 font-bold text-white" type="button">Share…</button>
+    <button class="copy-share rounded border border-teal-700 px-4 py-2 font-bold text-teal-700" type="button">Copy link</button>
+    <a class="rounded border border-slate-300 px-4 py-2 font-bold" :href="`https://bsky.app/intent/compose?text=${encodedTitle}%20${encodedUrl}`">Bluesky</a>
+    <a class="rounded border border-slate-300 px-4 py-2 font-bold" :href="`https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`">LinkedIn</a>
+    <a class="rounded border border-slate-300 px-4 py-2 font-bold" :href="`mailto:?subject=${encodedTitle}&body=${encodedUrl}`">Email</a>
+  </div><p class="share-status sr-only" aria-live="polite"></p>
+</section>
+<script webc:keep>
+document.querySelectorAll('[data-share-url]').forEach((section) => { const url = section.dataset.shareUrl; const title = section.dataset.shareTitle; const status = section.querySelector('.share-status'); const nativeButton = section.querySelector('.native-share'); if (navigator.share) { nativeButton.classList.remove('hidden'); nativeButton.addEventListener('click', async () => { try { await navigator.share({ title, url }); } catch (error) { if (error.name !== 'AbortError') status.textContent = 'Sharing was unavailable.'; } }); } section.querySelector('.copy-share').addEventListener('click', async () => { try { await navigator.clipboard.writeText(url); status.textContent = 'Link copied.'; } catch { status.textContent = 'Could not copy the link. Use the address from your browser.'; } }); });
+</script>

--- a/src/_includes/components/share-content.webc
+++ b/src/_includes/components/share-content.webc
@@ -1,14 +1,57 @@
-<script webc:setup>const encodedUrl = encodeURIComponent(url); const encodedTitle = encodeURIComponent(title);</script>
-<section class="mx-auto mt-8 max-w-4xl rounded-lg border border-slate-300 bg-white p-5" aria-labelledby="share-heading" :data-share-url="url" :data-share-title="title">
+<section class="mx-auto mt-8 max-w-4xl rounded-lg border border-slate-300 bg-white p-5" aria-labelledby="share-heading" :data-share-url="shareUrl" :data-share-title="shareTitle">
   <h2 id="share-heading" class="text-xl font-black">Share this</h2>
   <div class="mt-4 flex flex-wrap gap-3">
-    <button class="native-share hidden rounded bg-teal-700 px-4 py-2 font-bold text-white" type="button">Share…</button>
-    <button class="copy-share rounded border border-teal-700 px-4 py-2 font-bold text-teal-700" type="button">Copy link</button>
-    <a class="rounded border border-slate-300 px-4 py-2 font-bold" :href="`https://bsky.app/intent/compose?text=${encodedTitle}%20${encodedUrl}`">Bluesky</a>
-    <a class="rounded border border-slate-300 px-4 py-2 font-bold" :href="`https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`">LinkedIn</a>
-    <a class="rounded border border-slate-300 px-4 py-2 font-bold" :href="`mailto:?subject=${encodedTitle}&body=${encodedUrl}`">Email</a>
-  </div><p class="share-status sr-only" aria-live="polite"></p>
+    <button class="native-share share-action hidden" type="button"><i class="fa-solid fa-share-nodes" aria-hidden="true"></i><span>Share…</span></button>
+    <button class="copy-share share-action" type="button"><i class="fa-solid fa-link" aria-hidden="true"></i><span class="copy-share-label">Copy link</span></button>
+    <a class="share-action" :href="`https://bsky.app/intent/compose?text=${encodeURIComponent(`Read “${shareTitle}” ${shareUrl}`)}`"><i class="fa-brands fa-bluesky" aria-hidden="true"></i><span>Bluesky</span></a>
+    <a class="share-action" :href="`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(shareUrl)}`"><i class="fa-brands fa-linkedin" aria-hidden="true"></i><span>LinkedIn</span></a>
+    <a class="share-action" :href="`mailto:?subject=${encodeURIComponent(shareTitle)}&amp;body=${encodeURIComponent(shareUrl)}`"><i class="fa-solid fa-envelope" aria-hidden="true"></i><span>Email</span></a>
+  </div>
+  <p class="share-status sr-only" role="status" aria-live="polite"></p>
 </section>
 <script webc:keep>
-document.querySelectorAll('[data-share-url]').forEach((section) => { const url = section.dataset.shareUrl; const title = section.dataset.shareTitle; const status = section.querySelector('.share-status'); const nativeButton = section.querySelector('.native-share'); if (navigator.share) { nativeButton.classList.remove('hidden'); nativeButton.addEventListener('click', async () => { try { await navigator.share({ title, url }); } catch (error) { if (error.name !== 'AbortError') status.textContent = 'Sharing was unavailable.'; } }); } section.querySelector('.copy-share').addEventListener('click', async () => { try { await navigator.clipboard.writeText(url); status.textContent = 'Link copied.'; } catch { status.textContent = 'Could not copy the link. Use the address from your browser.'; } }); });
+async function copyShareUrl(url) {
+  if (navigator.clipboard?.writeText) { await navigator.clipboard.writeText(url); return; }
+  const input = document.createElement("textarea");
+  input.value = url;
+  input.setAttribute("readonly", "");
+  input.style.position = "fixed";
+  input.style.opacity = "0";
+  document.body.append(input);
+  input.select();
+  const copied = document.execCommand("copy");
+  input.remove();
+  if (!copied) throw new Error("Copy command was rejected");
+}
+
+document.querySelectorAll("[data-share-url]").forEach((section) => {
+  const url = section.dataset.shareUrl;
+  const title = section.dataset.shareTitle;
+  const status = section.querySelector(".share-status");
+  const nativeButton = section.querySelector(".native-share");
+  const copyButton = section.querySelector(".copy-share");
+  const copyLabel = section.querySelector(".copy-share-label");
+  if (navigator.share) {
+    nativeButton.classList.remove("hidden");
+    nativeButton.addEventListener("click", async () => {
+      try { await navigator.share({ title, url }); }
+      catch (error) { if (error.name !== "AbortError") status.textContent = "Sharing was unavailable."; }
+    });
+  }
+  copyButton.addEventListener("click", async () => {
+    try {
+      await copyShareUrl(url);
+      copyLabel.textContent = "Copied!";
+      status.textContent = "Link copied to clipboard.";
+      copyButton.classList.add("is-copied");
+    } catch {
+      copyLabel.textContent = "Copy failed";
+      status.textContent = "The link could not be copied. Copy it from the address bar instead.";
+    }
+    window.setTimeout(() => {
+      copyLabel.textContent = "Copy link";
+      copyButton.classList.remove("is-copied");
+    }, 2500);
+  });
+});
 </script>

--- a/src/_includes/layouts/post.webc
+++ b/src/_includes/layouts/post.webc
@@ -25,6 +25,6 @@ layout: base.webc
       Artwork and game details data from <a class="font-semibold text-teal-700 hover:text-teal-900" href="https://www.igdb.com/">IGDB.com</a>.
     </footer>
   </div>
-  <share-content :url="pageMetadata.canonicalUrl" :title="title"></share-content>
+  <share-content :share-url="pageMetadata.canonicalUrl" :share-title="title"></share-content>
   <content-navigation :@model="contentNavigation" :@site="site"></content-navigation>
 </article>

--- a/src/_includes/layouts/post.webc
+++ b/src/_includes/layouts/post.webc
@@ -25,5 +25,6 @@ layout: base.webc
       Artwork and game details data from <a class="font-semibold text-teal-700 hover:text-teal-900" href="https://www.igdb.com/">IGDB.com</a>.
     </footer>
   </div>
+  <share-content :url="pageMetadata.canonicalUrl" :title="title"></share-content>
   <content-navigation :@model="contentNavigation" :@site="site"></content-navigation>
 </article>

--- a/src/_includes/layouts/talk.webc
+++ b/src/_includes/layouts/talk.webc
@@ -21,6 +21,6 @@ layout: base.webc
     <section webc:if="content" class="prose-content" aria-label="Talk description" @raw="content"></section>
     <talk-details :@custom-data="customData"></talk-details>
   </div>
-  <share-content :url="pageMetadata.canonicalUrl" :title="title"></share-content>
+  <share-content :share-url="pageMetadata.canonicalUrl" :share-title="title"></share-content>
   <content-navigation :@model="contentNavigation" :@site="site"></content-navigation>
 </article>

--- a/src/_includes/layouts/talk.webc
+++ b/src/_includes/layouts/talk.webc
@@ -21,5 +21,6 @@ layout: base.webc
     <section webc:if="content" class="prose-content" aria-label="Talk description" @raw="content"></section>
     <talk-details :@custom-data="customData"></talk-details>
   </div>
+  <share-content :url="pageMetadata.canonicalUrl" :title="title"></share-content>
   <content-navigation :@model="contentNavigation" :@site="site"></content-navigation>
 </article>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -9,6 +9,30 @@
 html { scroll-behavior: smooth; }
 body { margin: 0; }
 
+.share-action {
+  align-items: center;
+  background: white;
+  border: 1px solid #cbd5e1;
+  border-radius: 9999px;
+  color: #334155;
+  cursor: pointer;
+  display: inline-flex;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  font-size: 0.875rem;
+  font-weight: 700;
+  gap: 0.5rem;
+  padding: 0.65rem 1rem;
+  text-decoration: none;
+}
+
+.share-action:hover,
+.share-action:focus-visible,
+.share-action.is-copied {
+  background: #f0fdfa;
+  border-color: #0d9488;
+  color: #0f766e;
+}
+
 .site-hero {
   background:
     radial-gradient(circle at 20% 20%, rgb(20 184 166 / 0.35), transparent 38%),

--- a/tests/site.test.js
+++ b/tests/site.test.js
@@ -10,6 +10,7 @@ import { prepareContentNavigation } from "../src/_lib/content-navigation.js";
 import site from "../src/_data/site.js";
 import { IGDB_CACHE_SCHEMA_VERSION, hasCachedImages, readIgdbManifest } from "../lib/igdb.js";
 import { telemetryBuildConfig } from "../lib/telemetry-build.js";
+import { campaignUrl } from "../lib/campaign-links.js";
 
 const output = join(process.cwd(), "_site");
 const content = join(process.cwd(), "src", "content");
@@ -355,4 +356,19 @@ test("content navigation ranks topics and provides family sequence", () => {
   assert.deepEqual(result.related.map((item) => item.url), ["/talk/", "/newer/", "/older/"]);
   assert.equal(result.previous.url, "/older/");
   assert.equal(result.next.url, "/newer/");
+});
+
+test("campaign links standardize supported sources", () => {
+  assert.equal(campaignUrl("/blog/example/", "bluesky", "example"), "https://david.wes.st/blog/example/?utm_source=bluesky&utm_medium=social&utm_campaign=example");
+  assert.throws(() => campaignUrl("https://example.com/post/", "youtube", "post"), /canonical published/);
+  assert.throws(() => campaignUrl("/blog/example/", "discord", "example"), /Unsupported/);
+});
+
+test("detail sharing uses canonical untracked links with accessible fallbacks", async () => {
+  const $ = await page("blog/from-11ty-to-wordpress-and-back-again/index.html");
+  const share = $("[data-share-url]");
+  assert.equal(share.attr("data-share-url"), "https://david.wes.st/blog/from-11ty-to-wordpress-and-back-again/");
+  assert.equal(share.find("button.copy-share").length, 1);
+  assert.equal(share.find("[aria-live='polite']").length, 1);
+  assert.doesNotMatch(share.html(), /utm_/);
 });

--- a/tests/site.test.js
+++ b/tests/site.test.js
@@ -362,6 +362,9 @@ test("campaign links standardize supported sources", () => {
   assert.equal(campaignUrl("/blog/example/", "bluesky", "example"), "https://david.wes.st/blog/example/?utm_source=bluesky&utm_medium=social&utm_campaign=example");
   assert.throws(() => campaignUrl("https://example.com/post/", "youtube", "post"), /canonical published/);
   assert.throws(() => campaignUrl("/blog/example/", "discord", "example"), /Unsupported/);
+  assert.throws(() => campaignUrl("/blog/example", "youtube", "example"), /canonical published/);
+  assert.throws(() => campaignUrl("/sitemap.xml", "youtube", "sitemap"), /canonical published/);
+  assert.throws(() => campaignUrl("/categories", "youtube", "categories"), /canonical published/);
 });
 
 test("detail sharing uses canonical untracked links with accessible fallbacks", async () => {

--- a/tests/site.test.js
+++ b/tests/site.test.js
@@ -373,5 +373,12 @@ test("detail sharing uses canonical untracked links with accessible fallbacks", 
   assert.equal(share.attr("data-share-url"), "https://david.wes.st/blog/from-11ty-to-wordpress-and-back-again/");
   assert.equal(share.find("button.copy-share").length, 1);
   assert.equal(share.find("[aria-live='polite']").length, 1);
+  assert.match(share.find("button.copy-share i").attr("class"), /fa-link/);
+  assert.ok(share.find("i.fa-solid, i.fa-brands").length >= 5);
+  const emailUrl = share.find("a[href^='mailto:']").attr("href");
+  assert.equal(emailUrl, "mailto:?subject=From%2011ty%20to%20Wordpress%20and%20Back%20Again&body=https%3A%2F%2Fdavid.wes.st%2Fblog%2Ffrom-11ty-to-wordpress-and-back-again%2F");
+  assert.doesNotMatch(emailUrl, /document|querySelector|navigator/);
+  assert.match($.html(), /execCommand\(["']copy["']\)/);
+  assert.equal(share.find(".copy-share-label").text(), "Copy link");
   assert.doesNotMatch(share.html(), /utm_/);
 });

--- a/tools/campaign-links.mjs
+++ b/tools/campaign-links.mjs
@@ -1,10 +1,10 @@
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import path from "node:path";
-import { campaignUrl } from "../lib/campaign-links.js";
+import { campaignUrl, canonicalPageUrl } from "../lib/campaign-links.js";
 const [input, campaign] = process.argv.slice(2);
 if (!input) throw new Error("Usage: pnpm campaign:links <canonical-url> [campaign]");
-const url = new URL(input, "https://david.wes.st");
-const outputPath = url.pathname.endsWith("/") ? path.join("_site", url.pathname, "index.html") : path.join("_site", url.pathname);
-if (!existsSync(path.resolve(outputPath))) throw new Error(`Published page was not found in _site: ${url.pathname}`);
+const url = canonicalPageUrl(input);
+const outputPath = path.join("_site", ...url.pathname.split("/").filter(Boolean), "index.html");
+if (!existsSync(path.resolve(outputPath)) || !statSync(path.resolve(outputPath)).isFile()) throw new Error(`Published canonical page was not found in _site: ${url.pathname}`);
 const defaultCampaign = campaign || url.pathname.split("/").filter(Boolean).at(-1) || "homepage";
 for (const source of ["youtube", "bluesky", "linkedin", "instagram"]) console.log(`${source}: ${campaignUrl(url.href, source, defaultCampaign)}`);

--- a/tools/campaign-links.mjs
+++ b/tools/campaign-links.mjs
@@ -1,0 +1,10 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { campaignUrl } from "../lib/campaign-links.js";
+const [input, campaign] = process.argv.slice(2);
+if (!input) throw new Error("Usage: pnpm campaign:links <canonical-url> [campaign]");
+const url = new URL(input, "https://david.wes.st");
+const outputPath = url.pathname.endsWith("/") ? path.join("_site", url.pathname, "index.html") : path.join("_site", url.pathname);
+if (!existsSync(path.resolve(outputPath))) throw new Error(`Published page was not found in _site: ${url.pathname}`);
+const defaultCampaign = campaign || url.pathname.split("/").filter(Boolean).at(-1) || "homepage";
+for (const source of ["youtube", "bluesky", "linkedin", "instagram"]) console.log(`${source}: ${campaignUrl(url.href, source, defaultCampaign)}`);


### PR DESCRIPTION
## What changed

- Added native sharing, canonical link copying, and direct Bluesky, LinkedIn, and email links.
- Added accessible status and no-JavaScript fallbacks.
- Added a validated campaign-link command for YouTube, Bluesky, LinkedIn, and Instagram.
- Documented platform distribution workflows.

## Why

Canonical website content needs low-friction visitor sharing and consistent owner-published campaign links without polluting canonical URLs.

## Impact

Posts and talks gain sharing controls; maintainers gain repeatable campaign URLs. No engagement or user data is introduced.

## Validation

- `pnpm test` — 37 tests passed
- Content integrity passed for 185 documents, 197 assets, 258 topics, and 209 legacy URLs

## Acceptance checklist

- [x] Visitor sharing always uses canonical untracked URLs.
- [x] Native, copy, direct, and no-JavaScript paths are present.
- [x] Campaign sources and canonical origins are validated.
- [x] Unsupported and compatibility URLs are rejected.

## Stack

Depends on #39 → #38 → #36.