### PR TITLE
Preserve homepage mosaic; add type-specific share/archive actions

### DIFF
--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -20,9 +20,9 @@ export default {
     { name: "YouTube", url: "https://youtube.com/davidwesst", iconClass: "fa-brands fa-youtube" },
   ],
   postTypes: {
-    article: { label: "Article", iconClass: "fa-solid fa-newspaper", fallbackColor: "#0f766e" },
-    gamelog: { label: "Gamelog", iconClass: "fa-solid fa-gamepad", fallbackColor: "#7c3aed" },
-    dungeonlog: { label: "Dungeonlog", iconClass: "fa-solid fa-dungeon", fallbackColor: "#b45309" },
-    talk: { label: "Talk", iconClass: "fa-solid fa-person-chalkboard", fallbackColor: "#0369a1" },
+    article: { label: "Article", archiveUrl: "/blog/articles/", iconClass: "fa-solid fa-newspaper", fallbackColor: "#0f766e" },
+    gamelog: { label: "Gamelog", archiveUrl: "/blog/gamelogs/", iconClass: "fa-solid fa-gamepad", fallbackColor: "#7c3aed" },
+    dungeonlog: { label: "Dungeonlog", archiveUrl: "/blog/dungeonlogs/", iconClass: "fa-solid fa-dungeon", fallbackColor: "#b45309" },
+    talk: { label: "Talk", archiveUrl: "/talks/", iconClass: "fa-solid fa-person-chalkboard", fallbackColor: "#0369a1" },
   },
 };

--- a/src/_includes/components/content-actions.webc
+++ b/src/_includes/components/content-actions.webc
@@ -1,0 +1,92 @@
+<script webc:setup>
+  function contentType(type, site) {
+    const value = site.postTypes[type];
+    if (!value) throw new Error(`Unknown content type for content actions: ${type}`);
+    return value;
+  }
+
+  function canonicalUrl(page, site) {
+    return new URL(page.url, site.url).href;
+  }
+
+  function emailUrl(title, page, site) {
+    const url = canonicalUrl(page, site);
+    return `mailto:?subject=${encodeURIComponent(title)}&body=${encodeURIComponent(`Read “${title}”: ${url}`)}`;
+  }
+
+  function blueskyUrl(title, page, site) {
+    return `https://bsky.app/intent/compose?text=${encodeURIComponent(`Read “${title}” ${canonicalUrl(page, site)}`)}`;
+  }
+
+  function linkedInUrl(page, site) {
+    return `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(canonicalUrl(page, site))}`;
+  }
+</script>
+
+<aside class="content-actions mt-12 border-t border-slate-200 pt-8" aria-label="Share and explore">
+  <h2 class="text-center text-sm font-black uppercase tracking-[0.18em] text-slate-500">Share this <span @text="contentType(type, site).label.toLowerCase()"></span></h2>
+  <div class="mt-4 flex flex-wrap justify-center gap-3" data-share-actions :data-share-url="canonicalUrl(page, site)">
+    <a class="share-action" :href="emailUrl(title, page, site)">
+      <i class="fa-solid fa-envelope" aria-hidden="true"></i><span>Email</span>
+    </a>
+    <a class="share-action" :href="blueskyUrl(title, page, site)" target="_blank" rel="noopener noreferrer">
+      <i class="fa-brands fa-bluesky" aria-hidden="true"></i><span>Bluesky</span>
+    </a>
+    <a class="share-action" :href="linkedInUrl(page, site)" target="_blank" rel="noopener noreferrer">
+      <i class="fa-brands fa-linkedin" aria-hidden="true"></i><span>LinkedIn</span>
+    </a>
+    <button class="share-action" type="button" data-copy-link>
+      <i class="fa-solid fa-link" aria-hidden="true"></i><span data-copy-label>Copy link</span>
+    </button>
+    <p class="sr-only" role="status" aria-live="polite" data-copy-status></p>
+  </div>
+  <p class="mt-8 text-center">
+    <a class="font-bold text-teal-700 hover:text-teal-900" :href="contentType(type, site).archiveUrl">
+      Explore the complete <span @text="contentType(type, site).label.toLowerCase()"></span> archive <span aria-hidden="true">→</span>
+    </a>
+  </p>
+</aside>
+
+<script webc:keep>
+  async function copyShareUrl(url) {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(url);
+      return;
+    }
+
+    const input = document.createElement("textarea");
+    input.value = url;
+    input.setAttribute("readonly", "");
+    input.style.position = "fixed";
+    input.style.opacity = "0";
+    document.body.append(input);
+    input.select();
+    const copied = document.execCommand("copy");
+    input.remove();
+    if (!copied) throw new Error("Copy command was rejected");
+  }
+
+  document.querySelectorAll("[data-share-actions]").forEach((actions) => {
+    const button = actions.querySelector("[data-copy-link]");
+    const label = actions.querySelector("[data-copy-label]");
+    const status = actions.querySelector("[data-copy-status]");
+    if (!button || !label || !status) return;
+
+    button.addEventListener("click", async () => {
+      try {
+        await copyShareUrl(actions.dataset.shareUrl);
+        label.textContent = "Copied!";
+        status.textContent = "Link copied to clipboard.";
+        button.classList.add("is-copied");
+      } catch {
+        label.textContent = "Copy failed";
+        status.textContent = "The link could not be copied. Copy it from the address bar instead.";
+      }
+
+      window.setTimeout(() => {
+        label.textContent = "Copy link";
+        button.classList.remove("is-copied");
+      }, 2500);
+    });
+  });
+</script>

--- a/src/_includes/layouts/post.webc
+++ b/src/_includes/layouts/post.webc
@@ -21,6 +21,7 @@ layout: base.webc
     <game-details webc:if="type === 'gamelog'" :@game="gameMetadata"></game-details>
     <gamelog-details webc:if="type === 'gamelog'" :@custom-data="customData"></gamelog-details>
     <section class="prose-content" aria-label="Post content" @raw="content"></section>
+    <content-actions :type="type" :title="title" :@site="site" :@page="page"></content-actions>
     <footer webc:if="type === 'gamelog' && gameMetadata" class="mt-10 border-t border-slate-200 pt-5 text-center text-sm text-slate-500">
       Artwork and game details data from <a class="font-semibold text-teal-700 hover:text-teal-900" href="https://www.igdb.com/">IGDB.com</a>.
     </footer>

--- a/src/_includes/layouts/talk.webc
+++ b/src/_includes/layouts/talk.webc
@@ -20,5 +20,6 @@ layout: base.webc
     <p webc:if="summary" class="mb-8 border-l-4 border-teal-600 pl-5 font-serif text-xl leading-8 text-slate-700" @text="summary"></p>
     <section webc:if="content" class="prose-content" aria-label="Talk description" @raw="content"></section>
     <talk-details :@custom-data="customData"></talk-details>
+    <content-actions type="talk" :title="title" :@site="site" :@page="page"></content-actions>
   </div>
 </article>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -46,6 +46,31 @@ body { margin: 0; }
   -webkit-line-clamp: 3;
 }
 
+.share-action {
+  align-items: center;
+  background: white;
+  border: 1px solid #cbd5e1;
+  border-radius: 9999px;
+  color: #334155;
+  cursor: pointer;
+  display: inline-flex;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  font-size: 0.875rem;
+  font-weight: 700;
+  gap: 0.5rem;
+  padding: 0.65rem 1rem;
+  text-decoration: none;
+  transition: background-color 150ms ease, border-color 150ms ease, color 150ms ease;
+}
+
+.share-action:hover,
+.share-action:focus-visible,
+.share-action.is-copied {
+  background: #f0fdfa;
+  border-color: #0d9488;
+  color: #0f766e;
+}
+
 @media (min-width: 1024px) {
   .home-posts { grid-template-columns: repeat(6, minmax(0, 1fr)); }
 

--- a/tests/site.test.js
+++ b/tests/site.test.js
@@ -83,6 +83,15 @@ test("Font Awesome CSS and webfonts are included in the build", async () => {
   assert.ok(solidFont.length > 0);
 });
 
+test("the home feed keeps its asymmetric mosaic at large viewports", async () => {
+  const stylesheet = await readFile(join(process.cwd(), "src", "styles", "main.css"), "utf8");
+  assert.match(stylesheet, /\.home-posts\s*>\s*li:nth-child\(1\)[\s\S]*grid-column:\s*span 2/);
+  assert.match(stylesheet, /\.home-posts\s*>\s*li:nth-child\(4\)[\s\S]*grid-column:\s*span 3/);
+  assert.match(stylesheet, /\.home-posts\s*>\s*li:nth-child\(6\)[\s\S]*grid-column:\s*span 4/);
+  assert.match(stylesheet, /\.home-posts\s*>\s*li:nth-child\(1\) figure[\s\S]*height:\s*18rem/);
+  assert.match(stylesheet, /\.home-posts\s*>\s*li:nth-child\(4\) figure[\s\S]*height:\s*14rem/);
+});
+
 test("operational telemetry is branch-gated and served as a first-party asset", async () => {
   const $ = await page("index.html");
   const telemetry = telemetryBuildConfig();
@@ -174,6 +183,26 @@ test("representative post types render normalized data", async () => {
   const dungeonlog = await page("blog/2026-03-16/index.html");
   assert.equal(dungeonlog("h1").text(), "The Queen Who Refused to Die");
   assert.ok(dungeonlog("figure img").length);
+});
+
+test("detail pages offer type-specific archives and functional share actions", async () => {
+  const cases = [
+    ["blog/from-11ty-to-wordpress-and-back-again/index.html", "article", "/blog/articles/"],
+    ["blog/clair-obscur-expedition-33/index.html", "gamelog", "/blog/gamelogs/"],
+    ["blog/2026-03-16/index.html", "dungeonlog", "/blog/dungeonlogs/"],
+    ["talks/no-mission-impossible/index.html", "talk", "/talks/"],
+  ];
+
+  for (const [path, type, archiveUrl] of cases) {
+    const $ = await page(path);
+    const actions = $(".content-actions");
+    assert.equal(actions.find(`a[href='${archiveUrl}']`).text().replace(/\s+/g, " ").trim(), `Explore the complete ${type} archive →`);
+    assert.match(actions.find("a").first().attr("href"), /^mailto:\?subject=[^&]+&body=[^&]+$/);
+    assert.equal(actions.find("a").first().attr("href").includes("javascript"), false);
+    assert.equal(actions.find("[data-copy-link]").attr("type"), "button");
+    assert.equal(actions.find("[data-copy-status][aria-live='polite']").length, 1);
+    assert.match(actions.find("[data-copy-link] i").attr("class"), /fa-link/);
+  }
 });
 
 test("post visuals use banners or accessible type-specific fallbacks", async () => {


### PR DESCRIPTION
### Motivation
- Keep the Ghostwind-inspired asymmetric homepage mosaic introduced in PR #38 instead of collapsing featured/recent posts into a uniform grid.  
- Make the bottom post link wording context-aware as requested in PR #39 so it reads “Explore the complete <post-type> archive”.  
- Provide lightweight Font Awesome-powered share actions and fix sharing/copy behavior from PR #40 so email links are encoded and copy gives visible feedback.  

### Description
- Preserve the mosaic layout and card sizing by keeping and asserting the row-span and per-item image-height rules in `src/styles/main.css`.  
- Add `archiveUrl` to each `postTypes` entry in `src/_data/site.js` and use that value to render type-specific archive links.  
- Add a reusable `content-actions` component at `src/_includes/components/content-actions.webc` that provides Font Awesome Email, Bluesky, LinkedIn, and Copy Link controls; email links are URL-encoded and copy uses the Clipboard API with a textarea fallback and an accessible live-region status.  
- Wire the component into post and talk layouts (`src/_includes/layouts/post.webc`, `src/_includes/layouts/talk.webc`), add share button styles in `src/styles/main.css`, and add regression tests in `tests/site.test.js` that assert the mosaic CSS and detail-page share/archive behavior.  

### Testing
- Ran the full automated suite with `pnpm test`, which performs a build, `check:content`, and Node tests, and all tests passed (35/35).  
- The Eleventy build and the repository content-integrity checks completed successfully during the test run.  
- Attempted browser binary install for Playwright failed due to an environment download restriction (HTTP 403) but this did not affect the `pnpm test` results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8548a15f088330a8fa4b393ec45f46)